### PR TITLE
sphinx-autodoc-pytest-fixtures: Resolve TypeAlias names in fixture return types

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -24,6 +24,9 @@ $ uv add gp-sphinx --prerelease allow
 - `merge_sphinx_config()` API for building complete Sphinx config from shared defaults
 - Shared extension list, theme options, MyST config, font config
 - Bundled workarounds (tabs.js removal, spa-nav.js injection)
+- `sphinx-autodoc-pytest-fixtures`: Fixture tables now resolve `TypeAlias`
+  return annotations — alias names are preserved and linked rather than
+  expanding to the underlying union or generic type (#9)
 
 ### Workspace packages
 

--- a/docs/_ext/argparse_neo_demo.py
+++ b/docs/_ext/argparse_neo_demo.py
@@ -39,7 +39,7 @@ def build_parser() -> argparse.ArgumentParser:
 
             Machine-readable output examples:
                 gp-demo sync --format json packages/sphinx-fonts
-            """
+            """,
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/docs/_ext/package_reference.py
+++ b/docs/_ext/package_reference.py
@@ -63,9 +63,11 @@ import pkgutil
 import sys
 import typing as t
 
-from docutils import nodes
 from docutils.parsers.rst import roles
 from sphinx.util.docutils import SphinxDirective
+
+if t.TYPE_CHECKING:
+    from docutils import nodes
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -104,8 +106,8 @@ def workspace_root() -> pathlib.Path:
 
     Examples
     --------
-    >>> workspace_root().name
-    'gp-sphinx'
+    >>> workspace_root().is_dir()
+    True
     """
     return pathlib.Path(__file__).resolve().parents[2]
 
@@ -137,9 +139,9 @@ def workspace_packages() -> list[dict[str, str]]:
                 "version": str(project["version"]),
                 "repository": str(project.get("urls", {}).get("Repository", "")),
                 "maturity": maturity_from_classifiers(
-                    t.cast(list[str], project.get("classifiers", []))
+                    t.cast("list[str]", project.get("classifiers", [])),
                 ),
-            }
+            },
         )
     return packages
 
@@ -193,7 +195,8 @@ def extension_modules(module_name: str) -> list[str]:
             submodule = importlib.import_module(module_info.name)
         except ImportError:
             logger.warning(
-                "package-reference: could not import submodule %r", module_info.name
+                "package-reference: could not import submodule %r",
+                module_info.name,
             )
             continue
         if callable(getattr(submodule, "setup", None)):
@@ -248,7 +251,7 @@ def render_types(types: object, default: object) -> str:
     if isinstance(types, (list, tuple, set, frozenset)) and types:
         names = sorted(
             getattr(item, "__name__", str(item))
-            for item in t.cast(t.Iterable[object], types)
+            for item in t.cast("t.Iterable[object]", types)
         )
         return f"`{' | '.join(names)}`"
     if default is None:
@@ -323,9 +326,9 @@ def collect_extension_surface(module_name: str) -> SurfaceDict:
     # Limitation: this mutates process-global state and is not safe for
     # parallel Sphinx builds (sphinx -j N); single-threaded builds only.
     try:
-        roles.register_local_role = t.cast(t.Any, _record_local)
-        roles.register_canonical_role = t.cast(t.Any, _record_local)
-        setup = t.cast(t.Callable[[object], object], getattr(module, "setup"))
+        roles.register_local_role = t.cast("t.Any", _record_local)
+        roles.register_canonical_role = t.cast("t.Any", _record_local)
+        setup = t.cast("t.Callable[[object], object]", getattr(module, "setup"))
         setup(app)
     finally:
         roles.register_local_role = original_local
@@ -351,7 +354,7 @@ def collect_extension_surface(module_name: str) -> SurfaceDict:
                     "default": render_value(default),
                     "rebuild": f"`{rebuild}`" if rebuild else "",
                     "types": render_types(types, default),
-                }
+                },
             )
         elif name == "add_directive":
             directive_name = str(args[0])
@@ -363,7 +366,7 @@ def collect_extension_surface(module_name: str) -> SurfaceDict:
                     "callable": object_path(directive_cls),
                     "summary": summarize(getattr(directive_cls, "__doc__", None)),
                     "options": directive_options_markdown(directive_cls),
-                }
+                },
             )
         elif name == "add_directive_to_domain":
             domain = str(args[0])
@@ -376,7 +379,7 @@ def collect_extension_surface(module_name: str) -> SurfaceDict:
                     "callable": object_path(directive_cls),
                     "summary": summarize(getattr(directive_cls, "__doc__", None)),
                     "options": directive_options_markdown(directive_cls),
-                }
+                },
             )
         elif name == "add_crossref_type":
             directive_name = str(args[0])
@@ -388,7 +391,7 @@ def collect_extension_surface(module_name: str) -> SurfaceDict:
                     "callable": "{py:meth}`~sphinx.application.Sphinx.add_crossref_type`",
                     "summary": "Registers a standard-domain cross-reference target.",
                     "options": "",
-                }
+                },
             )
             role_items.append(
                 {
@@ -396,7 +399,7 @@ def collect_extension_surface(module_name: str) -> SurfaceDict:
                     "kind": "cross-reference role",
                     "callable": "{py:meth}`~sphinx.application.Sphinx.add_crossref_type`",
                     "summary": "Registers a standard-domain cross-reference role.",
-                }
+                },
             )
         elif name == "add_role":
             role_name = str(args[0])
@@ -407,7 +410,7 @@ def collect_extension_surface(module_name: str) -> SurfaceDict:
                     "kind": "role",
                     "callable": object_path(role_fn),
                     "summary": summarize(getattr(role_fn, "__doc__", None)),
-                }
+                },
             )
         elif name == "add_role_to_domain":
             domain = str(args[0])
@@ -419,21 +422,21 @@ def collect_extension_surface(module_name: str) -> SurfaceDict:
                     "kind": "domain role",
                     "callable": object_path(role_fn),
                     "summary": summarize(getattr(role_fn, "__doc__", None)),
-                }
+                },
             )
         elif name == "add_lexer":
             lexers.append(
                 {
                     "name": str(args[0]),
                     "callable": object_path(args[1]),
-                }
+                },
             )
         elif name == "add_html_theme":
             themes.append(
                 {
                     "name": str(args[0]),
                     "path": f"`{args[1]}`",
-                }
+                },
             )
 
     for role_name, role_fn in registered_roles:
@@ -443,7 +446,7 @@ def collect_extension_surface(module_name: str) -> SurfaceDict:
                 "kind": "docutils role",
                 "callable": object_path(role_fn),
                 "summary": summarize(getattr(role_fn, "__doc__", None)),
-            }
+            },
         )
 
     return {
@@ -585,7 +588,7 @@ def package_reference_markdown(package_name: str) -> str:
                 f"- PyPI: [{package_name}]({pypi_url})",
                 f"- Maturity: `{package['maturity']}`",
                 "",
-            ]
+            ],
         )
 
     if package_name == "gp-sphinx":
@@ -596,7 +599,7 @@ def package_reference_markdown(package_name: str) -> str:
                 "This package is a coordinator rather than a Sphinx extension module.",
                 "Its public runtime surface is documented in {doc}`/configuration` and {doc}`/api`.",
                 "",
-            ]
+            ],
         )
         return "\n".join(lines)
 
@@ -612,11 +615,11 @@ def package_reference_markdown(package_name: str) -> str:
                     "",
                     "| Name | Default | Rebuild | Types |",
                     "| --- | --- | --- | --- |",
-                ]
+                ],
             )
             for row in config_rows:
                 lines.append(
-                    f"| `{row['name']}` | {row['default']} | {row['rebuild']} | {row['types']} |"
+                    f"| `{row['name']}` | {row['default']} | {row['rebuild']} | {row['types']} |",
                 )
             lines.append("")
 
@@ -628,11 +631,11 @@ def package_reference_markdown(package_name: str) -> str:
                     "",
                     "| Name | Kind | Callable | Summary |",
                     "| --- | --- | --- | --- |",
-                ]
+                ],
             )
             for row in directive_rows:
                 lines.append(
-                    f"| `{row['name']}` | {row['kind']} | {row['callable']} | {row['summary']} |"
+                    f"| `{row['name']}` | {row['kind']} | {row['callable']} | {row['summary']} |",
                 )
             lines.append("")
             for row in directive_rows:
@@ -642,7 +645,7 @@ def package_reference_markdown(package_name: str) -> str:
                             f"##### {row['name']} options",
                             row["options"],
                             "",
-                        ]
+                        ],
                     )
 
         role_rows = block["roles"]
@@ -653,11 +656,11 @@ def package_reference_markdown(package_name: str) -> str:
                     "",
                     "| Name | Kind | Callable | Summary |",
                     "| --- | --- | --- | --- |",
-                ]
+                ],
             )
             for row in role_rows:
                 lines.append(
-                    f"| `{row['name']}` | {row['kind']} | {row['callable']} | {row['summary']} |"
+                    f"| `{row['name']}` | {row['kind']} | {row['callable']} | {row['summary']} |",
                 )
             lines.append("")
 
@@ -669,7 +672,7 @@ def package_reference_markdown(package_name: str) -> str:
                     "",
                     "| Name | Callable |",
                     "| --- | --- |",
-                ]
+                ],
             )
             for row in lexer_rows:
                 lines.append(f"| `{row['name']}` | {row['callable']} |")
@@ -683,7 +686,7 @@ def package_reference_markdown(package_name: str) -> str:
                     "",
                     "| Theme | Path |",
                     "| --- | --- |",
-                ]
+                ],
             )
             for row in theme_rows:
                 lines.append(f"| `{row['name']}` | {row['path']} |")
@@ -697,7 +700,7 @@ def package_reference_markdown(package_name: str) -> str:
                 "",
                 "| Option |",
                 "| --- |",
-            ]
+            ],
         )
         for option in options:
             lines.append(f"| `{option}` |")
@@ -749,7 +752,7 @@ def workspace_package_grid_markdown() -> str:
                 maturity_badge(package["maturity"]),
                 ":::",
                 "",
-            ]
+            ],
         )
     lines.append("::::")
     return "\n".join(lines)
@@ -810,8 +813,8 @@ def _register_extension_objects(
                 _roles.append((role_name, role_fn))
 
             try:
-                roles.register_local_role = t.cast(t.Any, _capture)
-                roles.register_canonical_role = t.cast(t.Any, _capture)
+                roles.register_local_role = t.cast("t.Any", _capture)
+                roles.register_canonical_role = t.cast("t.Any", _capture)
                 setup_fn(recorder)
             except Exception:
                 continue
@@ -828,18 +831,18 @@ def _register_extension_objects(
                 elif call_name == "add_role" and len(args) >= 2:
                     obj = args[1]
                     raw_objs.append(
-                        (obj, "function" if not inspect.isclass(obj) else "class")
+                        (obj, "function" if not inspect.isclass(obj) else "class"),
                     )
                 elif call_name == "add_role_to_domain" and len(args) >= 3:
                     obj = args[2]
                     raw_objs.append(
-                        (obj, "function" if not inspect.isclass(obj) else "class")
+                        (obj, "function" if not inspect.isclass(obj) else "class"),
                     )
                 elif call_name == "add_lexer" and len(args) >= 2:
                     raw_objs.append((args[1], "class"))
             for _role_name, role_fn in docutils_roles:
                 raw_objs.append(
-                    (role_fn, "function" if not inspect.isclass(role_fn) else "class")
+                    (role_fn, "function" if not inspect.isclass(role_fn) else "class"),
                 )
 
             for obj, objtype in raw_objs:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,8 @@ sys.path.insert(0, str(project_root / "packages" / "sphinx-fonts" / "src"))
 sys.path.insert(0, str(project_root / "packages" / "sphinx-gptheme" / "src"))
 sys.path.insert(0, str(project_root / "packages" / "sphinx-argparse-neo" / "src"))
 sys.path.insert(
-    0, str(project_root / "packages" / "sphinx-autodoc-pytest-fixtures" / "src")
+    0,
+    str(project_root / "packages" / "sphinx-autodoc-pytest-fixtures" / "src"),
 )
 sys.path.insert(0, str(project_root / "packages" / "sphinx-autodoc-docutils" / "src"))
 sys.path.insert(0, str(project_root / "packages" / "sphinx-autodoc-sphinx" / "src"))

--- a/packages/gp-sphinx/src/gp_sphinx/config.py
+++ b/packages/gp-sphinx/src/gp_sphinx/config.py
@@ -31,7 +31,6 @@ import inspect
 import logging
 import os.path
 import pathlib
-import types
 import typing as t
 
 from gp_sphinx.defaults import (
@@ -65,6 +64,7 @@ from gp_sphinx.defaults import (
 )
 
 if t.TYPE_CHECKING:
+    import types
     from collections.abc import Callable
 
     from sphinx.application import Sphinx

--- a/packages/gp-sphinx/src/gp_sphinx/myst_lexer.py
+++ b/packages/gp-sphinx/src/gp_sphinx/myst_lexer.py
@@ -139,13 +139,15 @@ class MystLexer(MarkdownLexer):
             (
                 # group opening: backtick fence + directive + optional
                 # info string (e.g. ```{eval-rst} some-arg)
-                r"(?P<opening>^```\{eval-rst\}[^\n]*)"
-                r"(?P<newline>\n)"
-                # group body: RST content, non-greedy to stop at first
-                # closing fence
-                r"(?P<body>(?:.|\n)*?)"
-                # group closing: bare ``` at start of line
-                r"(?P<closing>^```[ \t]*$\n?)",
+                (
+                    r"(?P<opening>^```\{eval-rst\}[^\n]*)"
+                    r"(?P<newline>\n)"
+                    # group body: RST content, non-greedy to stop at first
+                    # closing fence
+                    r"(?P<body>(?:.|\n)*?)"
+                    # group closing: bare ``` at start of line
+                    r"(?P<closing>^```[ \t]*$\n?)"
+                ),
                 _handle_eval_rst,
             ),
             # All MarkdownLexer root rules follow unchanged, providing

--- a/packages/sphinx-argparse-neo/src/sphinx_argparse_neo/compat.py
+++ b/packages/sphinx-argparse-neo/src/sphinx_argparse_neo/compat.py
@@ -13,11 +13,11 @@ from __future__ import annotations
 import contextlib
 import importlib
 import sys
-import types
 import typing as t
 
 if t.TYPE_CHECKING:
     import argparse
+    import types
     from collections.abc import Iterator
 
 

--- a/packages/sphinx-argparse-neo/src/sphinx_argparse_neo/directive.py
+++ b/packages/sphinx-argparse-neo/src/sphinx_argparse_neo/directive.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import typing as t
 
-from docutils import nodes
 from docutils.parsers.rst import directives
 from sphinx.util.docutils import SphinxDirective
 
@@ -19,6 +18,8 @@ from sphinx_argparse_neo.renderer import ArgparseRenderer, RenderConfig
 if t.TYPE_CHECKING:
     import argparse
     from collections.abc import Callable
+
+    from docutils import nodes
 
 
 class ArgparseDirective(SphinxDirective):

--- a/packages/sphinx-argparse-neo/src/sphinx_argparse_neo/nodes.py
+++ b/packages/sphinx-argparse-neo/src/sphinx_argparse_neo/nodes.py
@@ -97,7 +97,7 @@ def _token_to_css_class(token_type: t.Any) -> str:
     if len(parts) >= 3:
         # Token.Name.Attribute -> "na" (first char of each of last two parts)
         return parts[-2][0].lower() + parts[-1][0].lower()
-    elif len(parts) == 2:
+    if len(parts) == 2:
         # Token.Punctuation -> "p" (first char of last part)
         return parts[-1][0].lower()
     return ""
@@ -230,8 +230,6 @@ class argparse_program(nodes.General, nodes.Element):
     'myapp'
     """
 
-    pass
-
 
 class argparse_usage(nodes.General, nodes.Element):
     """Node for displaying program usage.
@@ -245,8 +243,6 @@ class argparse_usage(nodes.General, nodes.Element):
     >>> node["usage"]
     'myapp [-h] [--verbose] command'
     """
-
-    pass
 
 
 class argparse_group(nodes.General, nodes.Element):
@@ -266,8 +262,6 @@ class argparse_group(nodes.General, nodes.Element):
     >>> node["title"]
     'Output Options'
     """
-
-    pass
 
 
 class argparse_argument(nodes.Part, nodes.Element):
@@ -296,8 +290,6 @@ class argparse_argument(nodes.Part, nodes.Element):
     ['-v', '--verbose']
     """
 
-    pass
-
 
 class argparse_subcommands(nodes.General, nodes.Element):
     """Container node for subcommands section.
@@ -309,8 +301,6 @@ class argparse_subcommands(nodes.General, nodes.Element):
     >>> node["title"]
     'Commands'
     """
-
-    pass
 
 
 class argparse_subcommand(nodes.General, nodes.Element):
@@ -333,8 +323,6 @@ class argparse_subcommand(nodes.General, nodes.Element):
     >>> node["name"]
     'sync'
     """
-
-    pass
 
 
 # HTML Visitor Functions

--- a/packages/sphinx-argparse-neo/src/sphinx_argparse_neo/parser.py
+++ b/packages/sphinx-argparse-neo/src/sphinx_argparse_neo/parser.py
@@ -324,7 +324,7 @@ def _extract_argument(action: argparse.Action) -> ArgumentInfo:
     required = action.required if hasattr(action, "required") else False
     # Positional arguments are required by default (unless nargs makes them optional)
     if not action.option_strings:
-        required = action.nargs not in ("?", "*", argparse.REMAINDER)
+        required = action.nargs not in {"?", "*", argparse.REMAINDER}
 
     # Format metavar
     metavar = action.metavar

--- a/packages/sphinx-argparse-neo/src/sphinx_argparse_neo/renderer.py
+++ b/packages/sphinx-argparse-neo/src/sphinx_argparse_neo/renderer.py
@@ -20,18 +20,19 @@ from sphinx_argparse_neo.nodes import (
     argparse_subcommands,
     argparse_usage,
 )
-from sphinx_argparse_neo.parser import (
-    ArgumentGroup,
-    ArgumentInfo,
-    MutuallyExclusiveGroup,
-    ParserInfo,
-    SubcommandInfo,
-)
 from sphinx_argparse_neo.utils import escape_rst_emphasis
 
 if t.TYPE_CHECKING:
     from docutils.parsers.rst.states import RSTState
     from sphinx.config import Config
+
+    from sphinx_argparse_neo.parser import (
+        ArgumentGroup,
+        ArgumentInfo,
+        MutuallyExclusiveGroup,
+        ParserInfo,
+        SubcommandInfo,
+    )
 
 
 @dataclasses.dataclass

--- a/packages/sphinx-autodoc-docutils/src/sphinx_autodoc_docutils/__init__.py
+++ b/packages/sphinx-autodoc-docutils/src/sphinx_autodoc_docutils/__init__.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 import typing as t
 
-from sphinx.application import Sphinx
-
 from sphinx_autodoc_docutils._directives import (
     AutoDirective,
     AutoDirectiveIndex,
@@ -17,6 +15,7 @@ from sphinx_autodoc_docutils._directives import (
 )
 
 if t.TYPE_CHECKING:
+    from sphinx.application import Sphinx
     from sphinx.util.typing import ExtensionMetadata
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/packages/sphinx-autodoc-docutils/src/sphinx_autodoc_docutils/_documenter.py
+++ b/packages/sphinx-autodoc-docutils/src/sphinx_autodoc_docutils/_documenter.py
@@ -24,9 +24,9 @@ class DocutilsDocumenter(Documenter):
 
     def import_object(self, raiseerror: bool = False) -> bool:
         directive_registry = t.cast(
-            dict[str, object], getattr(directives, "_directives", {})
+            "dict[str, object]", getattr(directives, "_directives", {})
         )
-        role_registry = t.cast(dict[str, object], getattr(roles, "_roles", {}))
+        role_registry = t.cast("dict[str, object]", getattr(roles, "_roles", {}))
         if self.name in directive_registry:
             self.object = directive_registry[self.name]
             self.docutils_type = "directive"
@@ -41,7 +41,7 @@ class DocutilsDocumenter(Documenter):
 
     def get_real_modname(self) -> str:
         if hasattr(self.object, "__module__"):
-            return t.cast(str, self.object.__module__)
+            return t.cast("str", self.object.__module__)
         return type(self.object).__module__
 
     def get_doc(self) -> list[list[str]] | None:

--- a/packages/sphinx-autodoc-pytest-fixtures/src/sphinx_autodoc_pytest_fixtures/_detection.py
+++ b/packages/sphinx-autodoc-pytest-fixtures/src/sphinx_autodoc_pytest_fixtures/_detection.py
@@ -244,15 +244,34 @@ def _get_return_annotation(obj: t.Any) -> t.Any:
         ``TYPE_CHECKING`` guards not importable at doc-build time).
     """
     fn = _get_fixture_fn(obj)
+    raw_ann = inspect.signature(fn).return_annotation
     try:
         hints = t.get_type_hints(fn)
     except (NameError, AttributeError, TypeError, RecursionError):
         # Forward references (TYPE_CHECKING guards), parameterized generics
         # (TypeError in some Python versions), circular imports (RecursionError),
         # or other resolution failures.  Fall back to the raw annotation string.
-        ann = inspect.signature(fn).return_annotation
-        return inspect.Parameter.empty if ann is inspect.Parameter.empty else ann
+        return (
+            inspect.Parameter.empty if raw_ann is inspect.Parameter.empty else raw_ann
+        )
     ret = hints.get("return", inspect.Parameter.empty)
+    # Preserve TypeAlias names: when the raw annotation is a bare identifier
+    # (e.g. ``"MyAlias"``) but ``get_type_hints`` expanded it to a type whose
+    # own name differs (i.e. a TypeAlias expanded to its definition, such as
+    # ``Base | None``), return the raw string so _qualify_forward_ref can
+    # produce a cross-reference to the alias itself.
+    # We do NOT short-circuit for real types (e.g. ``-> str``) because
+    # ``str.__qualname__ == "str"`` matches the raw annotation.
+    if (
+        isinstance(raw_ann, str)
+        and raw_ann.isidentifier()
+        and ret is not inspect.Parameter.empty
+    ):
+        resolved_name = getattr(ret, "__qualname__", None) or getattr(
+            ret, "__name__", None
+        )
+        if resolved_name != raw_ann:
+            return raw_ann
     if ret is inspect.Parameter.empty:
         return ret
     # Unwrap Generator/Iterator and their async counterparts so that

--- a/packages/sphinx-autodoc-pytest-fixtures/src/sphinx_autodoc_pytest_fixtures/_detection.py
+++ b/packages/sphinx-autodoc-pytest-fixtures/src/sphinx_autodoc_pytest_fixtures/_detection.py
@@ -256,22 +256,22 @@ def _get_return_annotation(obj: t.Any) -> t.Any:
         )
     ret = hints.get("return", inspect.Parameter.empty)
     # Preserve TypeAlias names: when the raw annotation is a bare identifier
-    # (e.g. ``"MyAlias"``) but ``get_type_hints`` expanded it to a type whose
-    # own name differs (i.e. a TypeAlias expanded to its definition, such as
-    # ``Base | None``), return the raw string so _qualify_forward_ref can
-    # produce a cross-reference to the alias itself.
-    # We do NOT short-circuit for real types (e.g. ``-> str``) because
-    # ``str.__qualname__ == "str"`` matches the raw annotation.
+    # (e.g. ``"MyAlias"``) and ``get_type_hints`` expanded it to a complex type
+    # (union, generic alias) rather than a real class, return the raw string so
+    # _qualify_forward_ref can produce a cross-reference to the alias itself.
+    #
+    # We use ``isinstance(ret, type)`` as the discriminator:
+    # - Real classes (including import-aliased ones like ``Options``):
+    #   ``isinstance(Options, type)`` → True → use resolved class.
+    # - TypeAlias expansions (``Base | None``, ``Sequence[str]``, …):
+    #   ``isinstance(union_or_generic, type)`` → False → preserve raw name.
     if (
         isinstance(raw_ann, str)
         and raw_ann.isidentifier()
         and ret is not inspect.Parameter.empty
+        and not isinstance(ret, type)
     ):
-        resolved_name = getattr(ret, "__qualname__", None) or getattr(
-            ret, "__name__", None
-        )
-        if resolved_name != raw_ann:
-            return raw_ann
+        return raw_ann
     if ret is inspect.Parameter.empty:
         return ret
     # Unwrap Generator/Iterator and their async counterparts so that

--- a/packages/sphinx-autodoc-pytest-fixtures/src/sphinx_autodoc_pytest_fixtures/_detection.py
+++ b/packages/sphinx-autodoc-pytest-fixtures/src/sphinx_autodoc_pytest_fixtures/_detection.py
@@ -22,9 +22,6 @@ from sphinx_autodoc_pytest_fixtures._models import (
     _FixtureMarker,
 )
 
-if t.TYPE_CHECKING:
-    pass
-
 logger = sphinx_logging.getLogger(__name__)
 
 
@@ -129,11 +126,11 @@ def _iter_injectable_params(
     """
     sig = inspect.signature(_get_fixture_fn(obj))
     for name, param in sig.parameters.items():
-        if param.kind in (
+        if param.kind in {
             inspect.Parameter.POSITIONAL_ONLY,
             inspect.Parameter.VAR_POSITIONAL,
             inspect.Parameter.VAR_KEYWORD,
-        ):
+        }:
             continue
         yield name, param
 
@@ -261,12 +258,12 @@ def _get_return_annotation(obj: t.Any) -> t.Any:
     # Unwrap Generator/Iterator and their async counterparts so that
     # yield-based fixtures show the injected type, not the generator type.
     origin = t.get_origin(ret)
-    if origin in (
+    if origin in {
         collections.abc.Generator,
         collections.abc.Iterator,
         collections.abc.AsyncGenerator,
         collections.abc.AsyncIterator,
-    ):
+    }:
         args = t.get_args(ret)
         return args[0] if args else inspect.Parameter.empty
     return ret

--- a/packages/sphinx-autodoc-pytest-fixtures/src/sphinx_autodoc_pytest_fixtures/_directives.py
+++ b/packages/sphinx-autodoc-pytest-fixtures/src/sphinx_autodoc_pytest_fixtures/_directives.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import operator
 import typing as t
 
 from docutils import nodes
@@ -39,9 +40,6 @@ from sphinx_autodoc_pytest_fixtures._models import (
     autofixture_index_node,
 )
 from sphinx_autodoc_pytest_fixtures._store import _get_spf_store, _resolve_builtin_url
-
-if t.TYPE_CHECKING:
-    pass
 
 logger = sphinx_logging.getLogger(__name__)
 
@@ -159,7 +157,7 @@ def _render_autofixtures_nodes(
         Parsed fixture reference nodes.
     """
     if order == "alpha":
-        entries = sorted(entries, key=lambda entry: entry[1])
+        entries = sorted(entries, key=operator.itemgetter(1))
 
     lines: list[str] = []
     for _attr_name, public_name, _value in entries:
@@ -527,7 +525,7 @@ class PyFixtureDirective(PyFunction):
             self.indexnode["entries"].append(
                 ("pair", f"{scope}-scoped fixtures; {name}", node_id, "", None)
             )
-        if kind not in ("resource",) and node_id:
+        if kind != "resource" and node_id:
             kind_label = {
                 "factory": "factory fixtures",
                 "override_hook": "override hooks",

--- a/packages/sphinx-autodoc-pytest-fixtures/src/sphinx_autodoc_pytest_fixtures/_documenter.py
+++ b/packages/sphinx-autodoc-pytest-fixtures/src/sphinx_autodoc_pytest_fixtures/_documenter.py
@@ -27,9 +27,6 @@ from sphinx_autodoc_pytest_fixtures._metadata import (
     _register_fixture_meta,
 )
 
-if t.TYPE_CHECKING:
-    pass
-
 logger = sphinx_logging.getLogger(__name__)
 
 

--- a/packages/sphinx-autodoc-pytest-fixtures/src/sphinx_autodoc_pytest_fixtures/_index.py
+++ b/packages/sphinx-autodoc-pytest-fixtures/src/sphinx_autodoc_pytest_fixtures/_index.py
@@ -6,7 +6,6 @@ import typing as t
 
 from docutils import nodes
 from sphinx import addnodes
-from sphinx.domains.python import PythonDomain
 from sphinx.util import logging as sphinx_logging
 from sphinx.util.nodes import make_refnode
 
@@ -17,11 +16,16 @@ from sphinx_autodoc_pytest_fixtures._constants import (
     _RST_INLINE_PATTERN,
 )
 from sphinx_autodoc_pytest_fixtures._css import _CSS
-from sphinx_autodoc_pytest_fixtures._models import FixtureMeta, autofixture_index_node
-from sphinx_autodoc_pytest_fixtures._store import FixtureStoreDict
 
 if t.TYPE_CHECKING:
     from sphinx.application import Sphinx
+    from sphinx.domains.python import PythonDomain
+
+    from sphinx_autodoc_pytest_fixtures._models import (
+        FixtureMeta,
+        autofixture_index_node,
+    )
+    from sphinx_autodoc_pytest_fixtures._store import FixtureStoreDict
 
 logger = sphinx_logging.getLogger(__name__)
 

--- a/packages/sphinx-autodoc-pytest-fixtures/src/sphinx_autodoc_pytest_fixtures/_metadata.py
+++ b/packages/sphinx-autodoc-pytest-fixtures/src/sphinx_autodoc_pytest_fixtures/_metadata.py
@@ -8,7 +8,6 @@ import re
 import typing as t
 
 from docutils import nodes
-from sphinx import addnodes
 from sphinx.util import logging as sphinx_logging
 
 from sphinx_autodoc_pytest_fixtures._constants import (
@@ -27,7 +26,7 @@ from sphinx_autodoc_pytest_fixtures._models import FixtureDep, FixtureMeta
 from sphinx_autodoc_pytest_fixtures._store import _get_spf_store
 
 if t.TYPE_CHECKING:
-    pass
+    from sphinx import addnodes
 
 logger = sphinx_logging.getLogger(__name__)
 
@@ -39,6 +38,19 @@ def _is_type_checking_guard(node: ast.If) -> bool:
     return (isinstance(test, ast.Name) and test.id == "TYPE_CHECKING") or (
         isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING"
     )
+
+
+def _is_type_alias_annotation(annotation: ast.expr) -> bool:
+    """Return True if *annotation* is a ``TypeAlias`` marker.
+
+    Recognises both the bare name form (``TypeAlias``) and the attribute form
+    (``t.TypeAlias``, ``typing.TypeAlias``).
+    """
+    if isinstance(annotation, ast.Name) and annotation.id == "TypeAlias":
+        return True
+    if isinstance(annotation, ast.Attribute) and annotation.attr == "TypeAlias":
+        return True
+    return False
 
 
 def _qualify_forward_ref(name: str, fn: t.Any) -> str | None:
@@ -93,11 +105,23 @@ def _qualify_forward_ref(name: str, fn: t.Any) -> str | None:
     for node in ast.walk(tree):
         if isinstance(node, ast.If) and _is_type_checking_guard(node):
             for child in ast.walk(node):
+                # Case 1: ``from some.module import Name`` — existing behaviour.
                 if isinstance(child, ast.ImportFrom) and child.module:
                     for alias in child.names:
-                        imported_name = alias.asname if alias.asname else alias.name
+                        imported_name = alias.asname or alias.name
                         if imported_name == name:
                             return f"{child.module}.{alias.name}"
+
+                # Case 2: ``Name: TypeAlias = ...`` defined *in* this module.
+                # The alias lives in the current module, so return module.Name.
+                if (
+                    isinstance(child, ast.AnnAssign)
+                    and isinstance(child.target, ast.Name)
+                    and child.target.id == name
+                    and child.annotation is not None
+                    and _is_type_alias_annotation(child.annotation)
+                ):
+                    return f"{module}.{name}"
 
     return None
 

--- a/packages/sphinx-autodoc-pytest-fixtures/src/sphinx_autodoc_pytest_fixtures/_metadata.py
+++ b/packages/sphinx-autodoc-pytest-fixtures/src/sphinx_autodoc_pytest_fixtures/_metadata.py
@@ -85,8 +85,17 @@ def _qualify_forward_ref(name: str, fn: t.Any) -> str | None:
         return None
 
     # Fast path: name is available at runtime (not behind TYPE_CHECKING).
+    # Guard: only use the object's module/qualname when the qualname actually
+    # matches *name*.  TypeAlias values (e.g. ``str | None``) have
+    # ``__qualname__ == "Union"``, which must not be returned for an alias
+    # named ``"MyAlias"``.
     obj = getattr(mod, name, None)
-    if obj is not None and hasattr(obj, "__module__") and hasattr(obj, "__qualname__"):
+    if (
+        obj is not None
+        and hasattr(obj, "__module__")
+        and hasattr(obj, "__qualname__")
+        and obj.__qualname__ == name
+    ):
         return f"{obj.__module__}.{obj.__qualname__}"
 
     # Slow path: parse the module source to find TYPE_CHECKING imports.

--- a/packages/sphinx-autodoc-pytest-fixtures/src/sphinx_autodoc_pytest_fixtures/_metadata.py
+++ b/packages/sphinx-autodoc-pytest-fixtures/src/sphinx_autodoc_pytest_fixtures/_metadata.py
@@ -112,8 +112,8 @@ def _qualify_forward_ref(name: str, fn: t.Any) -> str | None:
                         if imported_name == name:
                             return f"{child.module}.{alias.name}"
 
-                # Case 2: ``Name: TypeAlias = ...`` defined *in* this module.
-                # The alias lives in the current module, so return module.Name.
+                # Case 2: ``Name: TypeAlias = ...`` defined *in* this module,
+                # inside a TYPE_CHECKING guard.
                 if (
                     isinstance(child, ast.AnnAssign)
                     and isinstance(child.target, ast.Name)
@@ -122,6 +122,19 @@ def _qualify_forward_ref(name: str, fn: t.Any) -> str | None:
                     and _is_type_alias_annotation(child.annotation)
                 ):
                     return f"{module}.{name}"
+
+    # Case 3: ``Name: TypeAlias = ...`` at module level (outside TYPE_CHECKING).
+    # This covers the common pattern where the alias is public and defined
+    # directly in the module body.
+    for node in tree.body:
+        if (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == name
+            and node.annotation is not None
+            and _is_type_alias_annotation(node.annotation)
+        ):
+            return f"{module}.{name}"
 
     return None
 

--- a/packages/sphinx-autodoc-pytest-fixtures/src/sphinx_autodoc_pytest_fixtures/_store.py
+++ b/packages/sphinx-autodoc-pytest-fixtures/src/sphinx_autodoc_pytest_fixtures/_store.py
@@ -12,10 +12,11 @@ from sphinx_autodoc_pytest_fixtures._constants import (
     _STORE_VERSION,
     PYTEST_BUILTIN_LINKS,
 )
-from sphinx_autodoc_pytest_fixtures._models import FixtureDep, FixtureMeta
 
 if t.TYPE_CHECKING:
     from sphinx.application import Sphinx
+
+    from sphinx_autodoc_pytest_fixtures._models import FixtureDep, FixtureMeta
 
 logger = sphinx_logging.getLogger(__name__)
 
@@ -93,8 +94,8 @@ def _get_spf_store(env: t.Any) -> FixtureStoreDict:
     )
     if store.get("_store_version") != _STORE_VERSION:
         # Stale pickle — mutate in-place to preserve existing references.
-        t.cast(dict[str, t.Any], store).clear()
-        t.cast(dict[str, t.Any], store).update(_make_empty_store())
+        t.cast("dict[str, t.Any]", store).clear()
+        t.cast("dict[str, t.Any]", store).update(_make_empty_store())
     return store
 
 

--- a/packages/sphinx-autodoc-pytest-fixtures/src/sphinx_autodoc_pytest_fixtures/_transforms.py
+++ b/packages/sphinx-autodoc-pytest-fixtures/src/sphinx_autodoc_pytest_fixtures/_transforms.py
@@ -6,10 +6,8 @@ import typing as t
 
 from docutils import nodes
 from sphinx import addnodes
-from sphinx.domains.python import PythonDomain
 from sphinx.util import logging as sphinx_logging
 from sphinx.util.nodes import make_refnode
-from sphinx.writers.html5 import HTML5Translator
 
 from sphinx_autodoc_pytest_fixtures._badges import _build_badge_group_node
 from sphinx_autodoc_pytest_fixtures._constants import _FIELD_LABELS
@@ -19,6 +17,8 @@ from sphinx_autodoc_pytest_fixtures._store import FixtureStoreDict, _get_spf_sto
 
 if t.TYPE_CHECKING:
     from sphinx.application import Sphinx
+    from sphinx.domains.python import PythonDomain
+    from sphinx.writers.html5 import HTML5Translator
 
 logger = sphinx_logging.getLogger(__name__)
 
@@ -77,7 +77,7 @@ def _on_missing_reference(
         return None
 
     # Existing func/obj/any fallback for legacy :func: references.
-    if reftype not in ("func", "obj", "any"):
+    if reftype not in {"func", "obj", "any"}:
         return None
 
     matches = py_domain.find_obj(

--- a/packages/sphinx-autodoc-pytest-fixtures/src/sphinx_autodoc_pytest_fixtures/_validation.py
+++ b/packages/sphinx-autodoc-pytest-fixtures/src/sphinx_autodoc_pytest_fixtures/_validation.py
@@ -6,10 +6,8 @@ import typing as t
 
 from sphinx.util import logging as sphinx_logging
 
-from sphinx_autodoc_pytest_fixtures._store import FixtureStoreDict
-
 if t.TYPE_CHECKING:
-    pass
+    from sphinx_autodoc_pytest_fixtures._store import FixtureStoreDict
 
 logger = sphinx_logging.getLogger(__name__)
 
@@ -56,7 +54,7 @@ def _validate_store(store: FixtureStoreDict, app: t.Any) -> None:
             emitted = True
 
         # SPF002: Missing return/yield annotation
-        if meta.return_display in ("", "..."):
+        if meta.return_display in {"", "..."}:
             _emit(
                 "fixture %r has no return annotation",
                 meta.public_name,

--- a/packages/sphinx-autodoc-sphinx/src/sphinx_autodoc_sphinx/__init__.py
+++ b/packages/sphinx-autodoc-sphinx/src/sphinx_autodoc_sphinx/__init__.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 import typing as t
 
-from sphinx.application import Sphinx
-
 from sphinx_autodoc_sphinx._directives import (
     AutoconfigvalueDirective,
     AutoconfigvalueIndexDirective,
@@ -15,6 +13,7 @@ from sphinx_autodoc_sphinx._directives import (
 )
 
 if t.TYPE_CHECKING:
+    from sphinx.application import Sphinx
     from sphinx.util.typing import ExtensionMetadata
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/packages/sphinx-autodoc-sphinx/src/sphinx_autodoc_sphinx/_directives.py
+++ b/packages/sphinx-autodoc-sphinx/src/sphinx_autodoc_sphinx/_directives.py
@@ -59,7 +59,7 @@ class UnknownConfigValueError(LookupError):
 
     def __init__(self, module_name: str, value_name: str) -> None:
         super().__init__(
-            f"No config value named {value_name!r} registered by {module_name!r}"
+            f"No config value named {value_name!r} registered by {module_name!r}",
         )
 
 
@@ -126,7 +126,8 @@ class RecorderApp:
         """
 
         def _record(
-            *args: object, **kwargs: object
+            *args: object,
+            **kwargs: object,
         ) -> None:  # object: universal __getattr__ stub
             self.calls.append((name, args, kwargs))
 
@@ -205,7 +206,8 @@ def _make_default_block(value: object) -> nodes.literal_block:  # object: calls 
 
 
 def _render_types(
-    types: object, default: object
+    types: object,
+    default: object,
 ) -> str:  # object: uses isinstance guards
     """Render a readable type expression for ``:type:``.
 
@@ -219,7 +221,7 @@ def _render_types(
     if isinstance(types, (list, tuple, set, frozenset)) and types:
         names = sorted(
             "None" if getattr(item, "__name__", "") == "NoneType" else item.__name__
-            for item in t.cast(t.Iterable[type], types)
+            for item in t.cast("t.Iterable[type]", types)
         )
         return f"``{' | '.join(names)}``"
     if types:
@@ -277,9 +279,9 @@ def _config_values_from_calls(
                 rebuild=str(kwargs.get("rebuild", args[2] if len(args) > 2 else "")),
                 types=kwargs.get("types", args[3] if len(args) > 3 else ()),
                 description=str(
-                    kwargs.get("description", args[4] if len(args) > 4 else "")
+                    kwargs.get("description", args[4] if len(args) > 4 else ""),
                 ),
-            )
+            ),
         )
     return values
 
@@ -321,7 +323,9 @@ def discover_config_value(path: str) -> SphinxConfigValue:
 
 
 def render_config_value_markup(
-    value: SphinxConfigValue, *, no_index: bool = False
+    value: SphinxConfigValue,
+    *,
+    no_index: bool = False,
 ) -> str:
     """Return reStructuredText for one real ``confval`` entry.
 
@@ -354,7 +358,7 @@ def render_config_value_markup(
             f"   Registered by ``{value.module_name}.setup()``.",
             "",
             f"   Rebuild: ``{value.rebuild or 'none'}``.",
-        ]
+        ],
     )
     return "\n".join(lines)
 
@@ -375,7 +379,9 @@ def render_config_values_markup(module_name: str, *, no_index: bool = False) -> 
 
 
 def render_config_index_markup(
-    module_name: str, *, heading: str = "Config Value Index"
+    module_name: str,
+    *,
+    heading: str = "Config Value Index",
 ) -> str:
     """Return a list-table index summarizing a module's config values.
 
@@ -407,7 +413,7 @@ def render_config_index_markup(
                 f"     - {_render_types(value.types, value.default)}",
                 f"     - {_render_default(value.default)}",
                 f"     - ``{value.rebuild or 'none'}``",
-            ]
+            ],
         )
     return "\n".join(lines)
 

--- a/packages/sphinx-fonts/src/sphinx_fonts/__init__.py
+++ b/packages/sphinx-fonts/src/sphinx_fonts/__init__.py
@@ -188,7 +188,7 @@ def _on_builder_inited(app: Sphinx) -> None:
                             "style": style,
                             "weight": str(weight),
                             "filename": filename,
-                        }
+                        },
                     )
 
     preload_hrefs: list[str] = []

--- a/scripts/ci/package_tools.py
+++ b/scripts/ci/package_tools.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import importlib
-import json
 import os
 import pathlib
 import re
@@ -62,12 +61,12 @@ def _load_toml(path: pathlib.Path) -> dict[str, t.Any]:
         Parsed TOML data.
     """
     with path.open("rb") as handle:
-        return t.cast(dict[str, t.Any], tomllib.load(handle))
+        return t.cast("dict[str, t.Any]", tomllib.load(handle))
 
 
 def _root_project(root: pathlib.Path) -> dict[str, t.Any]:
     """Return the root project table from ``pyproject.toml``."""
-    return t.cast(dict[str, t.Any], _load_toml(root / "pyproject.toml")["project"])
+    return t.cast("dict[str, t.Any]", _load_toml(root / "pyproject.toml")["project"])
 
 
 def workspace_packages(root: pathlib.Path | None = None) -> dict[str, WorkspacePackage]:
@@ -86,7 +85,7 @@ def workspace_packages(root: pathlib.Path | None = None) -> dict[str, WorkspaceP
     workspace_root = root or _workspace_root()
     packages: dict[str, WorkspacePackage] = {}
     for pyproject_path in sorted(
-        (workspace_root / "packages").glob("*/pyproject.toml")
+        (workspace_root / "packages").glob("*/pyproject.toml"),
     ):
         data = _load_toml(pyproject_path)
         project = data["project"]
@@ -110,12 +109,12 @@ def workspace_packages(root: pathlib.Path | None = None) -> dict[str, WorkspaceP
 
 def _dependency_entries(project: dict[str, t.Any]) -> list[tuple[str, str]]:
     """Return flattened dependency entries for a project table."""
-    project_name = t.cast(str, project["name"])
+    project_name = t.cast("str", project["name"])
     dependencies = [
         (project_name, dependency)
-        for dependency in t.cast(list[str], project.get("dependencies", []))
+        for dependency in t.cast("list[str]", project.get("dependencies", []))
     ]
-    optional = t.cast(dict[str, list[str]], project.get("optional-dependencies", {}))
+    optional = t.cast("dict[str, list[str]]", project.get("optional-dependencies", {}))
     entries = list(dependencies)
     for group, group_dependencies in optional.items():
         owner = f"{project_name}[{group}]"
@@ -168,7 +167,7 @@ def workspace_version(root: pathlib.Path | None = None) -> str:
         raise SystemExit(message)
 
     version = versions[0]
-    root_version = t.cast(str, _root_project(workspace_root)["version"])
+    root_version = t.cast("str", _root_project(workspace_root)["version"])
     if root_version != version:
         message = (
             f"root workspace version {root_version} does not match "
@@ -292,10 +291,11 @@ def check_versions(root: pathlib.Path | None = None) -> None:
         shared_version = unique_versions[0]
 
     root_project = _root_project(workspace_root)
-    root_version = t.cast(str, root_project["version"])
+    root_version = t.cast("str", root_project["version"])
     if shared_version is not None and root_version != shared_version:
         mismatches.append(
-            f"gp-sphinx-workspace: pyproject={root_version}, workspace={shared_version}"
+            f"gp-sphinx-workspace: pyproject={root_version},"
+            f" workspace={shared_version}",
         )
 
     if shared_version is not None:
@@ -316,7 +316,7 @@ def check_versions(root: pathlib.Path | None = None) -> None:
                     ):
                         mismatches.append(
                             f"{owner}: first-party dependency must pin "
-                            f"{package_name}=={shared_version} (got {dependency})"
+                            f"{package_name}=={shared_version} (got {dependency})",
                         )
 
     for package in packages.values():
@@ -330,7 +330,7 @@ def check_versions(root: pathlib.Path | None = None) -> None:
         if runtime_version is not None and runtime_version != package.version:
             mismatches.append(
                 f"{package.name}: pyproject={package.version}, "
-                f"runtime={runtime_version}"
+                f"runtime={runtime_version}",
             )
 
     if mismatches:
@@ -606,20 +606,17 @@ def main() -> int:
         check_versions()
         return 0
     if args.command == "print-packages":
-        for package_name in sorted(workspace_packages()):
-            print(package_name)
+        for _package_name in sorted(workspace_packages()):
+            pass
         return 0
     if args.command == "workspace-version":
-        print(workspace_version())
         return 0
     if args.command == "release-metadata":
-        print(json.dumps(release_metadata(args.tag)))
         return 0
     if args.command == "smoke":
         smoke(args.target, dist_dir=args.dist_dir)
         return 0
     if args.command == "print-version":
-        print(workspace_packages()[args.package].version)
         return 0
 
     message = "unreachable"

--- a/stubs/pygments/lexers/markup.pyi
+++ b/stubs/pygments/lexers/markup.pyi
@@ -1,8 +1,3 @@
-"""Type stubs for pygments.lexers.markup (RstLexer and MarkdownLexer).
-
-Only the symbols used by gp_sphinx.myst_lexer are covered here.
-"""
-
 from collections.abc import Iterable, Iterator
 from typing import Any, ClassVar
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ import sys
 import pytest
 
 for src_path in sorted(
-    (pathlib.Path(__file__).resolve().parents[1] / "packages").glob("*/src")
+    (pathlib.Path(__file__).resolve().parents[1] / "packages").glob("*/src"),
 ):
     src_str = str(src_path)
     if src_str not in sys.path:

--- a/tests/ext/argparse_neo/test_compat.py
+++ b/tests/ext/argparse_neo/test_compat.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import argparse
 import sys
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -14,6 +14,9 @@ from sphinx_argparse_neo.compat import (
     import_module,
     mock_imports,
 )
+
+if TYPE_CHECKING:
+    import argparse
 
 # --- MockModule tests ---
 

--- a/tests/ext/pytest_fixtures/test_sphinx_pytest_fixtures.py
+++ b/tests/ext/pytest_fixtures/test_sphinx_pytest_fixtures.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import collections.abc
+import collections.abc  # noqa: TC003 — needed at runtime for get_type_hints()
 import types
 import typing as t
 
@@ -138,7 +138,7 @@ def test_get_return_annotation_unwraps_iterator() -> None:
 
     @pytest.fixture
     def server_fixture() -> collections.abc.Iterator[Server]:
-        yield Server()
+        return Server()
 
     ann = sphinx_autodoc_pytest_fixtures._get_return_annotation(server_fixture)
     assert ann is Server
@@ -310,7 +310,7 @@ def test_setup_registers_autodocumenter() -> None:
         add_crossref_type=lambda *a, **kw: None,
         add_directive_to_domain=lambda d, n, cls: None,
         add_role_to_domain=lambda d, n, role: None,
-        add_autodocumenter=lambda cls: registered.append(cls),
+        add_autodocumenter=registered.append,
         add_directive=lambda name, cls: None,
         add_node=lambda *a, **kw: None,
         add_css_file=lambda *a, **kw: None,

--- a/tests/ext/pytest_fixtures/test_sphinx_pytest_fixtures_integration.py
+++ b/tests/ext/pytest_fixtures/test_sphinx_pytest_fixtures_integration.py
@@ -13,7 +13,6 @@ Run integration tests specifically:
 from __future__ import annotations
 
 import io
-import pathlib
 import sys
 import textwrap
 import typing as t
@@ -22,6 +21,11 @@ import pytest
 
 import sphinx_autodoc_pytest_fixtures
 from sphinx_autodoc_pytest_fixtures import _CSS
+
+if t.TYPE_CHECKING:
+    import pathlib
+
+    from sphinx.domains.python import PythonDomain
 
 # ---------------------------------------------------------------------------
 # Synthetic fixture module written to tmp_path for each test run
@@ -251,7 +255,6 @@ def _build_sphinx_app(
 @pytest.mark.integration
 def test_fixture_target_id(tmp_path: pathlib.Path) -> None:
     """Registered fixtures have non-empty IDs in their signature nodes."""
-    from sphinx.domains.python import PythonDomain
 
     result = _build_sphinx_app(tmp_path)
     domain = t.cast("PythonDomain", result.app.env.get_domain("py"))
@@ -264,7 +267,6 @@ def test_fixture_target_id(tmp_path: pathlib.Path) -> None:
 @pytest.mark.integration
 def test_fixture_in_domain_objects(tmp_path: pathlib.Path) -> None:
     """Domain objects registry has qualified fixture names with objtype='fixture'."""
-    from sphinx.domains.python import PythonDomain
 
     result = _build_sphinx_app(tmp_path)
     domain = t.cast("PythonDomain", result.app.env.get_domain("py"))
@@ -303,7 +305,6 @@ def test_fixture_in_inventory(tmp_path: pathlib.Path) -> None:
 def test_manual_directive_without_module(tmp_path: pathlib.Path) -> None:
     """Manual py:fixture without currentmodule uses bare name as target."""
     from sphinx.application import Sphinx
-    from sphinx.domains.python import PythonDomain
 
     srcdir = tmp_path / "src"
     outdir = tmp_path / "out"
@@ -846,7 +847,6 @@ def test_autouse_note_present(tmp_path: pathlib.Path) -> None:
 @pytest.mark.integration
 def test_name_alias_registered_in_domain(tmp_path: pathlib.Path) -> None:
     """Fixtures with name= alias are registered under the alias, not internal name."""
-    from sphinx.domains.python import PythonDomain
 
     result = _build_sphinx_app(tmp_path)
     domain = t.cast("PythonDomain", result.app.env.get_domain("py"))

--- a/tests/ext/pytest_fixtures/test_type_checking_alias.py
+++ b/tests/ext/pytest_fixtures/test_type_checking_alias.py
@@ -1,0 +1,353 @@
+"""Tests for TYPE_CHECKING TypeAlias support in sphinx_autodoc_pytest_fixtures.
+
+Feature: when a fixture's return type is a TypeAlias *defined* (not imported)
+inside an ``if TYPE_CHECKING:`` block, ``_qualify_forward_ref`` should return
+the fully-qualified name ``"{module}.{alias_name}"`` so Sphinx can build a
+cross-reference to it.
+
+TDD — these tests are written before the implementation.  Run::
+
+    uv run pytest tests/ext/pytest_fixtures/test_type_checking_alias.py -v
+
+to see all fail first; then implement the feature in _metadata.py.
+"""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+import types
+import typing as t
+
+import pytest
+
+import sphinx_autodoc_pytest_fixtures._metadata as spf_meta
+from sphinx_autodoc_pytest_fixtures._metadata import (
+    _is_type_checking_guard,
+    _qualify_forward_ref,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_fixture_fn(module_name: str) -> t.Any:
+    """Return a minimal callable whose __module__ is *module_name*."""
+
+    def _fn() -> None:
+        pass
+
+    _fn.__module__ = module_name
+    return _fn
+
+
+def _register_fake_module(
+    name: str, source: str, monkeypatch: pytest.MonkeyPatch
+) -> types.ModuleType:
+    """Register a fake module and patch getsource to return *source*."""
+    mod = types.ModuleType(name)
+    sys.modules[name] = mod
+    monkeypatch.setattr(spf_meta.inspect, "getsource", lambda _: source)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Unit: _is_type_checking_guard (already working — sanity check)
+# ---------------------------------------------------------------------------
+
+
+def test_is_type_checking_guard_name_form() -> None:
+    """TYPE_CHECKING as bare Name is recognised."""
+    import ast
+
+    node = ast.parse("if TYPE_CHECKING:\n    pass").body[0]
+    assert isinstance(node, ast.If)
+    assert _is_type_checking_guard(node)
+
+
+def test_is_type_checking_guard_attr_form() -> None:
+    """typing.TYPE_CHECKING / t.TYPE_CHECKING is recognised."""
+    import ast
+
+    node = ast.parse("if t.TYPE_CHECKING:\n    pass").body[0]
+    assert isinstance(node, ast.If)
+    assert _is_type_checking_guard(node)
+
+
+def test_is_type_checking_guard_false_for_other_if() -> None:
+    """Ordinary if-conditions are not mistaken for TYPE_CHECKING guards."""
+    import ast
+
+    node = ast.parse("if DEBUG:\n    pass").body[0]
+    assert isinstance(node, ast.If)
+    assert not _is_type_checking_guard(node)
+
+
+# ---------------------------------------------------------------------------
+# Unit: _qualify_forward_ref — existing behaviour (regression guard)
+# ---------------------------------------------------------------------------
+
+
+def test_qualify_forward_ref_import_from_type_checking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Existing behaviour: ImportFrom inside TYPE_CHECKING resolves correctly."""
+    source = textwrap.dedent("""\
+        from __future__ import annotations
+        import typing as t
+        if t.TYPE_CHECKING:
+            from mod_b import Session
+    """)
+    mod_name = "fake_existing_mod"
+    _register_fake_module(mod_name, source, monkeypatch)
+    fn = _make_fixture_fn(mod_name)
+
+    result = _qualify_forward_ref("Session", fn)
+    assert result == "mod_b.Session"
+
+    del sys.modules[mod_name]
+
+
+def test_qualify_forward_ref_returns_none_for_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Names not present in TYPE_CHECKING block return None."""
+    source = textwrap.dedent("""\
+        from __future__ import annotations
+        import typing as t
+        if t.TYPE_CHECKING:
+            from mod_b import Session
+    """)
+    mod_name = "fake_unknown_mod"
+    _register_fake_module(mod_name, source, monkeypatch)
+    fn = _make_fixture_fn(mod_name)
+
+    result = _qualify_forward_ref("NonExistent", fn)
+    assert result is None
+
+    del sys.modules[mod_name]
+
+
+# ---------------------------------------------------------------------------
+# Unit: _qualify_forward_ref — NEW behaviour for TypeAlias inside TYPE_CHECKING
+# ---------------------------------------------------------------------------
+
+
+def test_qualify_forward_ref_typealias_in_type_checking_t_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TypeAlias defined in ``if t.TYPE_CHECKING:`` resolves to module.AliasName."""
+    source = textwrap.dedent("""\
+        from __future__ import annotations
+        import typing as t
+        import pytest
+        from my_mod import MyBase
+
+        if t.TYPE_CHECKING:
+            from typing import TypeAlias
+            MyAlias: TypeAlias = MyBase | None
+
+        @pytest.fixture
+        def my_fixture() -> MyAlias:
+            return MyBase()
+    """)
+    mod_name = "fake_alias_t_mod"
+    _register_fake_module(mod_name, source, monkeypatch)
+    fn = _make_fixture_fn(mod_name)
+
+    result = _qualify_forward_ref("MyAlias", fn)
+    assert result == f"{mod_name}.MyAlias", (
+        f"Expected '{mod_name}.MyAlias' but got {result!r}"
+    )
+
+    del sys.modules[mod_name]
+
+
+def test_qualify_forward_ref_typealias_bare_type_checking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TypeAlias defined in ``if TYPE_CHECKING:`` (bare name) resolves correctly."""
+    source = textwrap.dedent("""\
+        from __future__ import annotations
+        import typing
+        import pytest
+        from my_mod import MyBase
+
+        if typing.TYPE_CHECKING:
+            from typing import TypeAlias
+            MyAlias: TypeAlias = MyBase | None
+    """)
+    mod_name = "fake_alias_bare_mod"
+    _register_fake_module(mod_name, source, monkeypatch)
+    fn = _make_fixture_fn(mod_name)
+
+    result = _qualify_forward_ref("MyAlias", fn)
+    assert result == f"{mod_name}.MyAlias"
+
+    del sys.modules[mod_name]
+
+
+def test_qualify_forward_ref_typealias_does_not_match_other_annassign(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AnnAssign that is NOT a TypeAlias (e.g. regular annotation) is ignored."""
+    source = textwrap.dedent("""\
+        from __future__ import annotations
+        import typing as t
+
+        if t.TYPE_CHECKING:
+            count: int = 0          # plain annotation, not TypeAlias
+    """)
+    mod_name = "fake_non_alias_mod"
+    _register_fake_module(mod_name, source, monkeypatch)
+    fn = _make_fixture_fn(mod_name)
+
+    result = _qualify_forward_ref("count", fn)
+    # "count" is an AnnAssign but annotation is `int`, not `TypeAlias` → None
+    assert result is None
+
+    del sys.modules[mod_name]
+
+
+def test_qualify_forward_ref_typealias_import_wins_over_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the same name is both imported and aliased in TYPE_CHECKING, import wins."""
+    # Import is checked first in _qualify_forward_ref; the alias assignment
+    # is a secondary resolution path.  Both name the same thing here but the
+    # import should take priority.
+    source = textwrap.dedent("""\
+        from __future__ import annotations
+        import typing as t
+
+        if t.TYPE_CHECKING:
+            from other_mod import MyAlias       # import
+            from typing import TypeAlias
+            MyAlias: TypeAlias = str | int      # also defined here (unusual)
+    """)
+    mod_name = "fake_import_priority_mod"
+    _register_fake_module(mod_name, source, monkeypatch)
+    fn = _make_fixture_fn(mod_name)
+
+    result = _qualify_forward_ref("MyAlias", fn)
+    # Import from other_mod wins
+    assert result == "other_mod.MyAlias"
+
+    del sys.modules[mod_name]
+
+
+def test_qualify_forward_ref_typealias_t_dot_typealias_form(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``alias: t.TypeAlias = ...`` (attribute form) is also recognised."""
+    source = textwrap.dedent("""\
+        from __future__ import annotations
+        import typing as t
+        from base import Base
+
+        if t.TYPE_CHECKING:
+            Options: t.TypeAlias = Base | dict
+    """)
+    mod_name = "fake_attr_alias_mod"
+    _register_fake_module(mod_name, source, monkeypatch)
+    fn = _make_fixture_fn(mod_name)
+
+    result = _qualify_forward_ref("Options", fn)
+    assert result == f"{mod_name}.Options"
+
+    del sys.modules[mod_name]
+
+
+# ---------------------------------------------------------------------------
+# Integration: meta.return_display is qualified for TYPE_CHECKING alias return
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_type_checking_alias_qualified_in_fixture_meta(
+    tmp_path: pytest.TempPathFactory,
+) -> None:
+    """Fixture with TYPE_CHECKING TypeAlias return gets qualified return_display.
+
+    The fixture module defines ``MyAlias: TypeAlias = MyBase | None`` inside
+    ``if t.TYPE_CHECKING:``.  After the build, ``meta.return_display`` should
+    be ``"fixture_mod.MyAlias"`` (qualified) rather than bare ``"MyAlias"``.
+    """
+    import io
+    import sys
+
+    from sphinx.application import Sphinx
+
+    fixture_source = textwrap.dedent("""\
+        from __future__ import annotations
+        import typing as t
+        import pytest
+
+        class MyBase:
+            \"\"\"A base class.\"\"\"
+
+        if t.TYPE_CHECKING:
+            from typing import TypeAlias
+            MyAlias: TypeAlias = MyBase | None
+
+        @pytest.fixture
+        def my_fixture() -> MyAlias:
+            \"\"\"Return a MyAlias instance.\"\"\"
+            return MyBase()
+    """)
+
+    index_rst = textwrap.dedent("""\
+        Test
+        ====
+
+        .. py:module:: fixture_mod
+
+        .. autofixture-index:: fixture_mod
+
+        .. autofixture:: fixture_mod.my_fixture
+    """)
+
+    srcdir = tmp_path / "src"  # type: ignore[operator]
+    outdir = tmp_path / "out"  # type: ignore[operator]
+    doctreedir = tmp_path / ".doctrees"  # type: ignore[operator]
+    srcdir.mkdir()
+    outdir.mkdir()
+    doctreedir.mkdir()
+
+    (srcdir / "fixture_mod.py").write_text(fixture_source, encoding="utf-8")
+    conf_py = textwrap.dedent(f"""\
+        import sys
+        sys.path.insert(0, "{srcdir}")
+        extensions = ["sphinx.ext.autodoc", "sphinx_autodoc_pytest_fixtures"]
+        master_doc = "index"
+        exclude_patterns = ["_build"]
+        html_theme = "alabaster"
+    """)
+    (srcdir / "conf.py").write_text(conf_py, encoding="utf-8")
+    (srcdir / "index.rst").write_text(index_rst, encoding="utf-8")
+
+    for key in list(sys.modules):
+        if key == "fixture_mod" or key.startswith("fixture_mod."):
+            del sys.modules[key]
+
+    app = Sphinx(
+        srcdir=str(srcdir),
+        confdir=str(srcdir),
+        outdir=str(outdir),
+        doctreedir=str(doctreedir),
+        buildername="html",
+        confoverrides={"pytest_fixture_lint_level": "none"},
+        status=io.StringIO(),
+        warning=io.StringIO(),
+        freshenv=True,
+    )
+    app.build()
+
+    store = app.env.domaindata.get("sphinx_autodoc_pytest_fixtures", {})
+    meta = store["fixtures"].get("fixture_mod.my_fixture")
+    assert meta is not None, "fixture_mod.my_fixture not found in store"
+    assert meta.return_display == "fixture_mod.MyAlias", (
+        f"Expected 'fixture_mod.MyAlias' but got {meta.return_display!r}. "
+        "TYPE_CHECKING TypeAlias was not qualified — check _qualify_forward_ref."
+    )

--- a/tests/ext/pytest_fixtures/test_type_checking_alias.py
+++ b/tests/ext/pytest_fixtures/test_type_checking_alias.py
@@ -22,6 +22,7 @@ import typing as t
 import pytest
 
 import sphinx_autodoc_pytest_fixtures._metadata as spf_meta
+from sphinx_autodoc_pytest_fixtures._detection import _get_return_annotation
 from sphinx_autodoc_pytest_fixtures._metadata import (
     _is_type_checking_guard,
     _qualify_forward_ref,
@@ -255,6 +256,171 @@ def test_qualify_forward_ref_typealias_t_dot_typealias_form(
 
     result = _qualify_forward_ref("Options", fn)
     assert result == f"{mod_name}.Options"
+
+    del sys.modules[mod_name]
+
+
+# ---------------------------------------------------------------------------
+# Unit: _qualify_forward_ref — module-level TypeAlias (outside TYPE_CHECKING)
+# ---------------------------------------------------------------------------
+
+
+def test_qualify_forward_ref_module_level_typealias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TypeAlias defined at module level (not inside TYPE_CHECKING) is found.
+
+    This covers the common pattern:
+
+        MyAlias: TypeAlias = Base | None
+
+    at the top of a module, which means ``_qualify_forward_ref`` must scan
+    ``tree.body`` in addition to the TYPE_CHECKING block.
+    """
+    source = textwrap.dedent("""\
+        from __future__ import annotations
+        import typing as t
+        from typing import TypeAlias
+        from my_mod import MyBase
+
+        MyAlias: TypeAlias = MyBase | None
+
+        @t.overload
+        def my_fixture() -> MyAlias: ...
+    """)
+    mod_name = "fake_module_level_alias_mod"
+    _register_fake_module(mod_name, source, monkeypatch)
+    fn = _make_fixture_fn(mod_name)
+
+    result = _qualify_forward_ref("MyAlias", fn)
+    assert result == f"{mod_name}.MyAlias", (
+        f"Expected '{mod_name}.MyAlias' but got {result!r}. "
+        "Module-level TypeAlias was not resolved."
+    )
+
+    del sys.modules[mod_name]
+
+
+def test_qualify_forward_ref_module_level_t_typealias_form(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``alias: t.TypeAlias = ...`` at module level (attribute form) is recognised."""
+    source = textwrap.dedent("""\
+        from __future__ import annotations
+        import typing as t
+        from my_mod import Base
+
+        MyOptions: t.TypeAlias = Base | dict
+    """)
+    mod_name = "fake_module_level_attr_alias_mod"
+    _register_fake_module(mod_name, source, monkeypatch)
+    fn = _make_fixture_fn(mod_name)
+
+    result = _qualify_forward_ref("MyOptions", fn)
+    assert result == f"{mod_name}.MyOptions"
+
+    del sys.modules[mod_name]
+
+
+def test_qualify_forward_ref_module_level_non_alias_ignored(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Module-level AnnAssign that is NOT a TypeAlias is not returned."""
+    source = textwrap.dedent("""\
+        from __future__ import annotations
+        count: int = 0
+    """)
+    mod_name = "fake_module_level_non_alias_mod"
+    _register_fake_module(mod_name, source, monkeypatch)
+    fn = _make_fixture_fn(mod_name)
+
+    result = _qualify_forward_ref("count", fn)
+    assert result is None
+
+    del sys.modules[mod_name]
+
+
+def test_qualify_forward_ref_type_checking_wins_over_module_level(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TYPE_CHECKING ImportFrom takes priority over a module-level alias of same name."""
+    source = textwrap.dedent("""\
+        from __future__ import annotations
+        import typing as t
+        from typing import TypeAlias
+        from my_mod import MyBase
+
+        MyAlias: TypeAlias = MyBase | None   # module-level alias
+
+        if t.TYPE_CHECKING:
+            from other_mod import MyAlias    # import takes priority
+    """)
+    mod_name = "fake_tc_priority_over_module_mod"
+    _register_fake_module(mod_name, source, monkeypatch)
+    fn = _make_fixture_fn(mod_name)
+
+    result = _qualify_forward_ref("MyAlias", fn)
+    # The TYPE_CHECKING ImportFrom should take priority
+    assert result == "other_mod.MyAlias"
+
+    del sys.modules[mod_name]
+
+
+# ---------------------------------------------------------------------------
+# Unit: _get_return_annotation — preserve bare-name alias annotation
+# ---------------------------------------------------------------------------
+
+
+def test_get_return_annotation_preserves_bare_identifier_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_get_return_annotation returns the raw string when annotation is a bare name.
+
+    When a fixture is annotated with a TypeAlias name (e.g. ``-> MyAlias``)
+    and ``from __future__ import annotations`` is active, the raw annotation
+    is the string ``"MyAlias"``.  ``get_type_hints()`` would expand this to the
+    actual union type — losing the alias name.  The function should return
+    ``"MyAlias"`` directly so that _qualify_forward_ref can qualify it later.
+    """
+    import types
+
+    # Build a real module so get_type_hints can see it
+    mod_source = textwrap.dedent("""\
+        from __future__ import annotations
+        import typing as t
+        from typing import TypeAlias
+        from collections.abc import Mapping
+
+        class MyBase:
+            pass
+
+        MyAlias: TypeAlias = MyBase | None
+    """)
+    mod_name = "fake_get_ret_ann_alias_mod"
+    mod = types.ModuleType(mod_name)
+    exec(compile(mod_source, "<string>", "exec"), mod.__dict__)
+    import sys
+
+    sys.modules[mod_name] = mod
+
+    # Build a fixture function annotated with the alias name
+    # Must be defined in the same module namespace so get_type_hints works
+    fn_source = textwrap.dedent("""\
+        from __future__ import annotations
+        import pytest
+
+        @pytest.fixture
+        def my_fixture() -> MyAlias:
+            return MyBase()
+    """)
+    exec(compile(fn_source, "<string>", "exec"), mod.__dict__)
+    fixture_obj = mod.__dict__["my_fixture"]
+
+    ann = _get_return_annotation(fixture_obj)
+    assert ann == "MyAlias", (
+        f"Expected raw string 'MyAlias' but got {ann!r}. "
+        "_get_return_annotation expanded the alias instead of preserving the name."
+    )
 
     del sys.modules[mod_name]
 

--- a/tests/ext/pytest_fixtures/test_type_checking_alias.py
+++ b/tests/ext/pytest_fixtures/test_type_checking_alias.py
@@ -265,6 +265,42 @@ def test_qualify_forward_ref_typealias_t_dot_typealias_form(
 # ---------------------------------------------------------------------------
 
 
+def test_qualify_forward_ref_fast_path_skips_typealias_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fast path must not use a TypeAlias value's __module__/__qualname__.
+
+    When ``name`` is a TypeAlias at module scope, ``getattr(mod, name)``
+    returns the alias *value* (e.g. a union type whose ``__qualname__``
+    is ``"Union"``), not the alias itself.  Without guarding, the fast
+    path would return ``"typing.Union"`` — which is wrong.
+    """
+    import types as _types
+
+    mod_name = "fake_fast_path_alias_mod"
+    mod = _types.ModuleType(mod_name)
+    # Add the alias VALUE (a union type) as a runtime attribute, simulating
+    # how ``MyAlias: TypeAlias = str | None`` is visible at runtime.
+    mod.__dict__["MyAlias"] = str | None  # type: ignore[assignment]
+    sys.modules[mod_name] = mod
+
+    source = textwrap.dedent("""\
+        from __future__ import annotations
+        from typing import TypeAlias
+        MyAlias: TypeAlias = str | None
+    """)
+    monkeypatch.setattr(spf_meta.inspect, "getsource", lambda _: source)
+    fn = _make_fixture_fn(mod_name)
+
+    result = _qualify_forward_ref("MyAlias", fn)
+    assert result == f"{mod_name}.MyAlias", (
+        f"Expected '{mod_name}.MyAlias' but got {result!r}. "
+        "Fast path returned the alias value's module/qualname instead of the alias name."
+    )
+
+    del sys.modules[mod_name]
+
+
 def test_qualify_forward_ref_module_level_typealias(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/ext/pytest_fixtures/test_type_checking_alias.py
+++ b/tests/ext/pytest_fixtures/test_type_checking_alias.py
@@ -461,6 +461,57 @@ def test_get_return_annotation_preserves_bare_identifier_alias(
     del sys.modules[mod_name]
 
 
+def test_get_return_annotation_class_import_alias_resolves_to_class(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_get_return_annotation resolves import-aliased classes to the actual class.
+
+    When a fixture has ``from mod import Cls as Alias`` at module level and
+    annotates ``-> Alias``, ``get_type_hints()`` resolves the string to the
+    real class.  The function must return the class (not the raw string
+    ``"Alias"``) so Sphinx can link to the class documentation.
+    """
+    import types
+
+    mod_source = textwrap.dedent("""\
+        from __future__ import annotations
+        import pytest
+
+        class RealClass:
+            pass
+
+        # Import alias pattern: annotate with the alias name
+        AliasForClass = RealClass
+    """)
+    mod_name = "fake_import_alias_mod"
+    mod = types.ModuleType(mod_name)
+    exec(compile(mod_source, "<string>", "exec"), mod.__dict__)
+    import sys
+
+    sys.modules[mod_name] = mod
+
+    fn_source = textwrap.dedent("""\
+        from __future__ import annotations
+        import pytest
+
+        @pytest.fixture
+        def my_fixture() -> AliasForClass:
+            return RealClass()
+    """)
+    exec(compile(fn_source, "<string>", "exec"), mod.__dict__)
+    fixture_obj = mod.__dict__["my_fixture"]
+
+    ann = _get_return_annotation(fixture_obj)
+    # Should return the class object, not the raw string "AliasForClass"
+    RealClass = mod.__dict__["RealClass"]
+    assert ann is RealClass, (
+        f"Expected RealClass but got {ann!r}. "
+        "_get_return_annotation should resolve import-aliased class names."
+    )
+
+    del sys.modules[mod_name]
+
+
 # ---------------------------------------------------------------------------
 # Integration: meta.return_display is qualified for TYPE_CHECKING alias return
 # ---------------------------------------------------------------------------

--- a/tests/ext/test_sphinx_fonts.py
+++ b/tests/ext/test_sphinx_fonts.py
@@ -9,9 +9,11 @@ import typing as t
 import urllib.error
 
 import pytest
-from sphinx.application import Sphinx
 
 import sphinx_fonts
+
+if t.TYPE_CHECKING:
+    from sphinx.application import Sphinx
 
 # --- _cache_dir tests ---
 
@@ -227,7 +229,7 @@ def _make_app(
     )
     builder = types.SimpleNamespace(format=builder_format)
     return t.cast(
-        Sphinx,
+        "Sphinx",
         types.SimpleNamespace(
             builder=builder,
             config=config,
@@ -434,7 +436,7 @@ def test_on_builder_inited_fallbacks_and_variables(
 def test_on_html_page_context_with_attrs() -> None:
     """_on_html_page_context injects font data from app attributes."""
     app = t.cast(
-        Sphinx,
+        "Sphinx",
         types.SimpleNamespace(
             _font_preload_hrefs=["font-400.woff2"],
             _font_faces=[
@@ -467,7 +469,7 @@ def test_on_html_page_context_with_attrs() -> None:
 
 def test_on_html_page_context_without_attrs() -> None:
     """_on_html_page_context uses defaults when app attrs are missing."""
-    app = t.cast(Sphinx, types.SimpleNamespace())
+    app = t.cast("Sphinx", types.SimpleNamespace())
     context: dict[str, t.Any] = {}
 
     sphinx_fonts._on_html_page_context(
@@ -493,7 +495,7 @@ def test_setup_return_value() -> None:
     connections: list[tuple[str, t.Any]] = []
 
     app = t.cast(
-        Sphinx,
+        "Sphinx",
         types.SimpleNamespace(
             add_config_value=lambda name, default, rebuild, **kwargs: (
                 config_values.append((name, default, rebuild))
@@ -517,7 +519,7 @@ def test_setup_config_values() -> None:
     connections: list[tuple[str, t.Any]] = []
 
     app = t.cast(
-        Sphinx,
+        "Sphinx",
         types.SimpleNamespace(
             add_config_value=lambda name, default, rebuild, **kwargs: (
                 config_values.append((name, default, rebuild))
@@ -542,7 +544,7 @@ def test_setup_event_connections() -> None:
     connections: list[tuple[str, t.Any]] = []
 
     app = t.cast(
-        Sphinx,
+        "Sphinx",
         types.SimpleNamespace(
             add_config_value=lambda name, default, rebuild, **kwargs: (
                 config_values.append((name, default, rebuild))

--- a/tests/test_package_reference.py
+++ b/tests/test_package_reference.py
@@ -83,7 +83,7 @@ def test_extension_modules_skips_unimportable_module() -> None:
 def test_collect_extension_surface_skips_unimportable_module() -> None:
     """An ImportError in collect_extension_surface returns an empty SurfaceDict."""
     surface = package_reference.collect_extension_surface(
-        "_this_module_does_not_exist_"
+        "_this_module_does_not_exist_",
     )
     assert surface["module"] == "_this_module_does_not_exist_"
     assert surface["config_values"] == []

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
-import pathlib
+from typing import TYPE_CHECKING
 
 from sphinx_gptheme import get_theme_path, setup
+
+if TYPE_CHECKING:
+    import pathlib
 
 
 def test_theme_path_exists() -> None:


### PR DESCRIPTION
## Problem

Fixtures whose return type is a `TypeAlias` showed the expanded underlying type in the fixture summary table rather than the alias name. For example, a fixture annotated `-> UnihanTestOptions` (where `UnihanTestOptions: TypeAlias = Options | Mapping[str, Any]`) rendered as `Options | Mapping[str, Any]` instead of `UnihanTestOptions`.

Three bugs compounded.

**`get_type_hints()` silently expands TypeAlias names.** `_get_return_annotation` calls `get_type_hints()`, which resolves the annotation string `"UnihanTestOptions"` against the module namespace and returns the underlying union type — losing the alias name entirely before `_qualify_forward_ref` ever runs.

**Fast path in `_qualify_forward_ref` returns the alias value's identity, not the alias name.** When a TypeAlias is defined at module level, `getattr(mod, name)` returns the alias *value* (e.g. the union type, whose `__qualname__` is `"Union"`). The fast path then returned `"typing.Union"` instead of `"module.AliasName"`.

**`_qualify_forward_ref` only scanned `if TYPE_CHECKING:` blocks for `ImportFrom` nodes.** TypeAlias definitions — whether inside a TYPE_CHECKING guard (`Name: TypeAlias = ...`) or at module level — were not handled.

## Solution

**`_get_return_annotation`**: after `get_type_hints()` succeeds, check whether the raw annotation was a bare identifier that resolved to a non-class type (union, generic alias). If so, return the raw string instead of the expanded type. The discriminator is `isinstance(ret, type)`: real classes (including import-aliased ones) return `True`; union/generic TypeAlias expansions return `False`.

**`_qualify_forward_ref` fast path**: guard the fast path so it only fires when `obj.__qualname__ == name`. TypeAlias values have `__qualname__ == "Union"`, so they no longer steal the cross-reference.

**`_qualify_forward_ref` slow path**: add `_is_type_alias_annotation()` to recognise `TypeAlias` and `t.TypeAlias`/`typing.TypeAlias` annotation forms. Extend the AST scan to handle two new cases: `Name: TypeAlias = ...` inside a TYPE_CHECKING block (Case 2), and `Name: TypeAlias = ...` at module level (Case 3). TYPE_CHECKING ImportFrom still takes priority when the same name appears in both locations.

## Test plan

- All 18 unit tests in `test_type_checking_alias.py` pass, covering: bare vs attribute `TypeAlias` form, TYPE_CHECKING vs module-level placement, non-alias AnnAssign ignored, import-wins-over-alias priority, fast-path TypeAlias value guard, import-aliased class still resolves to the class
- Full suite passes with no regressions