### PR TITLE
style(fix[fonts]): Load full weight range for IBM Plex Mono

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -30,10 +30,10 @@ $ uv add gp-sphinx --prerelease allow
 
 ### Bug fixes
 
-- Load font weight 300 for IBM Plex Sans and IBM Plex Mono
-  ([Furo](https://github.com/pradyunsg/furo) and sphinx-design use
-  `font-weight: 300` for lighter text, but the weight was never loaded,
-  causing browsers to synthesize a light variant)
+- Load full weight range `[300, 400, 500, 600, 700]` for both IBM Plex
+  Sans and IBM Plex Mono (badges render in monospace at `font-weight: 700`,
+  Furo code blocks use 300, and intermediate weights inherit from
+  surrounding context — previously only Sans had the full set)
 - Replace `font-weight: 650` with `700` in badge CSS across
   `sphinx-autodoc-pytest-fixtures`, `sphinx-gptheme`, and docs (650 is not
   a standard Fontsource weight, so browsers were synthesizing bold instead

--- a/packages/gp-sphinx/src/gp_sphinx/defaults.py
+++ b/packages/gp-sphinx/src/gp_sphinx/defaults.py
@@ -203,7 +203,7 @@ DEFAULT_SPHINX_FONTS: list[FontConfig] = [
         "family": "IBM Plex Mono",
         "package": "@fontsource/ibm-plex-mono",
         "version": "5.2.7",
-        "weights": [300, 400],
+        "weights": [300, 400, 500, 600, 700],
         "styles": ["normal", "italic"],
         "subset": "latin",
     },


### PR DESCRIPTION
## Summary

Follow-up to #11. Badges render in monospace at `font-weight: 700` but
IBM Plex Mono only loaded `[300, 400]`, causing browsers to synthesize
bold. This PR gives Mono the same full weight range as Sans.

- **IBM Plex Mono weights**: `[300, 400]` → `[300, 400, 500, 600, 700]`
- Updates CHANGES entry to reflect Mono now has the full set

## Test plan
- [x] `uv run ruff check .` — passes
- [x] `uv run ruff format .` — no changes
- [x] `uv run mypy` — no issues
- [x] `uv run pytest --reruns 0 -vvv` — 681 passed, 3 skipped
- [ ] Visual check: bold monospace badges render with real font