### PR TITLE
argparse_neo(fix[renderer]): Namespace section names by id_prefix

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -51,6 +51,11 @@ $ uv add gp-sphinx --prerelease allow
   after `BadgeNode` (`<span>`) replaced `<abbr>` in `sphinx-autodoc-api-style`
   and `sphinx-autodoc-pytest-fixtures`; restored via element-agnostic CSS
   selectors and correct fill defaults (#13)
+- `sphinx-argparse-neo`: Namespace implicit section targets (`section["names"]`)
+  by `id_prefix` in `render_usage_section`, `render_group_section`, and
+  `_create_example_section` so multi-page docs that embed `.. argparse::` via
+  MyST `{eval-rst}` no longer emit `duplicate label` warnings for `usage`,
+  `options`, `positional arguments`, and cross-page `examples` targets (#16)
 
 ### Workspace packages
 

--- a/packages/sphinx-argparse-neo/src/sphinx_argparse_neo/exemplar.py
+++ b/packages/sphinx-argparse-neo/src/sphinx_argparse_neo/exemplar.py
@@ -542,6 +542,8 @@ def _create_example_section(
     >>> section = _create_example_section("examples:", def_node)
     >>> section["ids"]
     ['examples']
+    >>> section["names"]
+    ['examples']
     >>> section[0].astext()
     'Examples'
 
@@ -549,6 +551,8 @@ def _create_example_section(
 
     >>> section = _create_example_section("examples:", def_node, page_prefix="sync")
     >>> section["ids"]
+    ['sync-examples']
+    >>> section["names"]
     ['sync-examples']
 
     Category-prefixed examples create descriptive section IDs:
@@ -569,7 +573,9 @@ def _create_example_section(
 
     section = nodes.section()
     section["ids"] = [section_id]
-    section["names"] = [nodes.fully_normalize_name(section_title)]
+    # Scope section name by section_id so multi-page docs don't collide on
+    # the implicit target docutils creates from section["names"].
+    section["names"] = [nodes.fully_normalize_name(section_id)]
 
     title = nodes.title(text=section_title)
     section += title

--- a/packages/sphinx-argparse-neo/src/sphinx_argparse_neo/renderer.py
+++ b/packages/sphinx-argparse-neo/src/sphinx_argparse_neo/renderer.py
@@ -274,11 +274,15 @@ class ArgparseRenderer:
         >>> section = renderer.render_usage_section(info)
         >>> section["ids"]
         ['usage']
+        >>> section["names"]
+        ['usage']
 
         With prefix for subcommand pages:
 
         >>> section = renderer.render_usage_section(info, id_prefix="load")
         >>> section["ids"]
+        ['load-usage']
+        >>> section["names"]
         ['load-usage']
         >>> section.children[0].astext()
         'Usage'
@@ -286,7 +290,9 @@ class ArgparseRenderer:
         section_id = f"{id_prefix}-usage" if id_prefix else "usage"
         section = nodes.section()
         section["ids"] = [section_id]
-        section["names"] = [nodes.fully_normalize_name("Usage")]
+        # Scope section name by id_prefix so multi-page docs don't collide
+        # on the implicit "usage" target docutils creates from section["names"].
+        section["names"] = [nodes.fully_normalize_name(section_id)]
         section += nodes.title("Usage", "Usage")
 
         usage_node = argparse_usage()
@@ -331,11 +337,15 @@ class ArgparseRenderer:
         >>> section = renderer.render_group_section(group)
         >>> section["ids"]
         ['positional-arguments']
+        >>> section["names"]
+        ['positional-arguments']
 
         With prefix for subcommand pages:
 
         >>> section = renderer.render_group_section(group, id_prefix="load")
         >>> section["ids"]
+        ['load-positional-arguments']
+        >>> section["names"]
         ['load-positional-arguments']
         >>> section.children[0].astext()
         'Positional Arguments'
@@ -351,10 +361,12 @@ class ArgparseRenderer:
         base_id = title.lower().replace(" ", "-")
         section_id = f"{id_prefix}-{base_id}" if id_prefix else base_id
 
-        # Create section wrapper for TOC discovery
+        # Create section wrapper for TOC discovery. Scope section name by
+        # id_prefix so multi-page docs don't collide on the implicit target
+        # docutils creates from section["names"].
         section = nodes.section()
         section["ids"] = [section_id]
-        section["names"] = [nodes.fully_normalize_name(title)]
+        section["names"] = [nodes.fully_normalize_name(section_id)]
 
         # Add title for TOC - Sphinx's TocTreeCollector looks for this
         section += nodes.title(title, title)

--- a/tests/ext/argparse_neo/test_multi_page_integration.py
+++ b/tests/ext/argparse_neo/test_multi_page_integration.py
@@ -1,0 +1,208 @@
+"""Integration test for multi-page duplicate-label scoping.
+
+Builds a synthetic Sphinx project with two MyST pages that each embed an
+``.. argparse::`` directive via ``{eval-rst}`` — matching the way downstream
+consumers (vcspull, tmuxp, libtmux, …) wire up their CLI docs. Asserts that
+the resulting build emits no ``duplicate label`` warnings for the shared
+``usage`` / ``options`` / ``positional arguments`` section names.
+
+See https://github.com/git-pull/gp-sphinx/issues/15.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import pathlib
+import re
+import sys
+import textwrap
+import typing as t
+
+import pytest
+
+if t.TYPE_CHECKING:
+    from sphinx.application import Sphinx
+
+
+_PARSER_MOD = textwrap.dedent(
+    """\
+    from __future__ import annotations
+
+    import argparse
+
+
+    def create_parser() -> argparse.ArgumentParser:
+        parser = argparse.ArgumentParser(prog="myapp")
+        sub = parser.add_subparsers(dest="command")
+
+        add = sub.add_parser("add", help="Add a resource")
+        add.add_argument("name", help="Name of the resource")
+        add.add_argument("--force", action="store_true", help="Force overwrite")
+
+        discover = sub.add_parser("discover", help="Scan for resources")
+        discover.add_argument("path", help="Directory to scan")
+        discover.add_argument("--depth", type=int, default=3, help="Recursion depth")
+
+        return parser
+    """,
+)
+
+
+_CONF_PY = textwrap.dedent(
+    """\
+    import sys
+    sys.path.insert(0, r"{srcdir}")
+
+    project = "argparse_neo_multipage"
+    extensions = [
+        "myst_parser",
+        "sphinx_argparse_neo",
+    ]
+    master_doc = "index"
+    exclude_patterns = ["_build"]
+    html_theme = "alabaster"
+    source_suffix = {{".md": "markdown"}}
+    """,
+)
+
+
+_INDEX_MD = textwrap.dedent(
+    """\
+    # Multi-page argparse
+
+    ```{toctree}
+    :maxdepth: 1
+
+    add
+    discover
+    ```
+    """,
+)
+
+
+_ADD_MD = textwrap.dedent(
+    """\
+    # Add
+
+    ```{eval-rst}
+    .. argparse::
+       :module: myapp_parser
+       :func: create_parser
+       :prog: myapp
+       :path: add
+    ```
+    """,
+)
+
+
+_DISCOVER_MD = textwrap.dedent(
+    """\
+    # Discover
+
+    ```{eval-rst}
+    .. argparse::
+       :module: myapp_parser
+       :func: create_parser
+       :prog: myapp
+       :path: discover
+    ```
+    """,
+)
+
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+class _Result(t.NamedTuple):
+    app: Sphinx
+    warnings: str
+
+
+def _purge_parser_module() -> None:
+    for key in list(sys.modules):
+        if key == "myapp_parser":
+            del sys.modules[key]
+
+
+def _build(tmp_path: pathlib.Path) -> _Result:
+    from sphinx.application import Sphinx
+
+    srcdir = tmp_path / "src"
+    outdir = tmp_path / "out"
+    doctreedir = tmp_path / ".doctrees"
+    srcdir.mkdir()
+    outdir.mkdir()
+    doctreedir.mkdir()
+
+    (srcdir / "myapp_parser.py").write_text(_PARSER_MOD, encoding="utf-8")
+    (srcdir / "conf.py").write_text(
+        _CONF_PY.format(srcdir=str(srcdir)),
+        encoding="utf-8",
+    )
+    (srcdir / "index.md").write_text(_INDEX_MD, encoding="utf-8")
+    (srcdir / "add.md").write_text(_ADD_MD, encoding="utf-8")
+    (srcdir / "discover.md").write_text(_DISCOVER_MD, encoding="utf-8")
+
+    status_buf = io.StringIO()
+    warning_buf = io.StringIO()
+
+    # Snapshot the `sphinx` logger state before building. Sphinx.__init__
+    # sets `sphinx.propagate = False` and attaches handlers that route events
+    # into the provided warning/status streams. If we don't restore these,
+    # subsequent tests that rely on `caplog` to capture sphinx-namespace
+    # warnings (e.g. the SPF lint tests in tests/ext/pytest_fixtures/) see
+    # empty records.
+    sphinx_logger = logging.getLogger("sphinx")
+    prev_propagate = sphinx_logger.propagate
+    prev_handlers = list(sphinx_logger.handlers)
+    prev_level = sphinx_logger.level
+
+    _purge_parser_module()
+    try:
+        app = Sphinx(
+            srcdir=str(srcdir),
+            confdir=str(srcdir),
+            outdir=str(outdir),
+            doctreedir=str(doctreedir),
+            buildername="html",
+            status=status_buf,
+            warning=warning_buf,
+            freshenv=True,
+        )
+        app.build()
+        return _Result(app=app, warnings=warning_buf.getvalue())
+    finally:
+        for h in list(sphinx_logger.handlers):
+            if h not in prev_handlers:
+                sphinx_logger.removeHandler(h)
+        sphinx_logger.propagate = prev_propagate
+        sphinx_logger.setLevel(prev_level)
+
+
+def _duplicate_label_lines(warnings: str) -> list[str]:
+    return [
+        _ANSI.sub("", line)
+        for line in warnings.splitlines()
+        if "duplicate label" in line
+    ]
+
+
+@pytest.mark.integration
+def test_multi_page_argparse_emits_no_duplicate_label_warnings(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Two MyST pages with ``.. argparse::`` must not collide on implicit targets.
+
+    Regression test for https://github.com/git-pull/gp-sphinx/issues/15 —
+    prior to the fix, ``section["names"]`` was left unscoped in
+    ``render_usage_section`` / ``render_group_section``, so every CLI page
+    produced identical ``usage`` / ``options`` / ``positional arguments``
+    implicit targets and Sphinx's std domain logged one ``duplicate label``
+    warning per collision.
+    """
+    result = _build(tmp_path)
+    duplicates = _duplicate_label_lines(result.warnings)
+    assert not duplicates, (
+        "Unexpected duplicate-label warnings in build output:\n" + "\n".join(duplicates)
+    )

--- a/tests/ext/argparse_neo/test_renderer_section_names.py
+++ b/tests/ext/argparse_neo/test_renderer_section_names.py
@@ -11,6 +11,11 @@ https://github.com/git-pull/gp-sphinx/issues/15.
 
 from __future__ import annotations
 
+import typing as t
+
+import pytest
+from docutils import nodes
+
 from sphinx_argparse_neo.parser import (
     ArgumentGroup,
     ArgumentInfo,
@@ -56,51 +61,98 @@ def _make_positional_group() -> ArgumentGroup:
     )
 
 
-def test_usage_section_names_match_ids_without_prefix() -> None:
-    """Without a prefix, usage section ``names`` equal its ``ids``."""
-    section = ArgparseRenderer().render_usage_section(_make_parser_info())
-    assert section["ids"] == ["usage"]
-    assert section["names"] == ["usage"]
-
-
-def test_usage_section_names_match_ids_with_prefix() -> None:
-    """With a prefix, usage section ``names`` are scoped the same as ``ids``."""
-    section = ArgparseRenderer().render_usage_section(
-        _make_parser_info(), id_prefix="load"
+def _render_usage(id_prefix: str) -> nodes.section:
+    return ArgparseRenderer().render_usage_section(
+        _make_parser_info(), id_prefix=id_prefix
     )
-    assert section["ids"] == ["load-usage"]
-    assert section["names"] == ["load-usage"]
 
 
-def test_group_section_names_match_ids_without_prefix() -> None:
-    """Without a prefix, group section ``names`` equal its ``ids``."""
-    section = ArgparseRenderer().render_group_section(_make_positional_group())
-    assert section["ids"] == ["positional-arguments"]
-    assert section["names"] == ["positional-arguments"]
-
-
-def test_group_section_names_match_ids_with_prefix() -> None:
-    """With a prefix, group section ``names`` are scoped the same as ``ids``."""
-    section = ArgparseRenderer().render_group_section(
-        _make_positional_group(), id_prefix="load"
+def _render_group(id_prefix: str) -> nodes.section:
+    return ArgparseRenderer().render_group_section(
+        _make_positional_group(), id_prefix=id_prefix
     )
-    assert section["ids"] == ["load-positional-arguments"]
-    assert section["names"] == ["load-positional-arguments"]
 
 
-def test_multi_page_usage_sections_do_not_collide() -> None:
-    """Two pages' usage sections must produce disjoint implicit targets."""
-    renderer = ArgparseRenderer()
-    page_a = renderer.render_usage_section(_make_parser_info(), id_prefix="page-a")
-    page_b = renderer.render_usage_section(_make_parser_info(), id_prefix="page-b")
-    assert set(page_a["names"]).isdisjoint(page_b["names"])
-    assert set(page_a["ids"]).isdisjoint(page_b["ids"])
+class SectionNameCase(t.NamedTuple):
+    """Inputs and expectations for one names-match-ids assertion."""
+
+    test_id: str
+    make_section: t.Callable[[str], nodes.section]
+    id_prefix: str
+    expected_id: str
 
 
-def test_multi_page_group_sections_do_not_collide() -> None:
-    """Two pages' group sections must produce disjoint implicit targets."""
-    renderer = ArgparseRenderer()
-    page_a = renderer.render_group_section(_make_positional_group(), id_prefix="page-a")
-    page_b = renderer.render_group_section(_make_positional_group(), id_prefix="page-b")
+_SECTION_NAME_CASES: list[SectionNameCase] = [
+    SectionNameCase(
+        test_id="usage-no-prefix",
+        make_section=_render_usage,
+        id_prefix="",
+        expected_id="usage",
+    ),
+    SectionNameCase(
+        test_id="usage-with-prefix",
+        make_section=_render_usage,
+        id_prefix="load",
+        expected_id="load-usage",
+    ),
+    SectionNameCase(
+        test_id="group-no-prefix",
+        make_section=_render_group,
+        id_prefix="",
+        expected_id="positional-arguments",
+    ),
+    SectionNameCase(
+        test_id="group-with-prefix",
+        make_section=_render_group,
+        id_prefix="load",
+        expected_id="load-positional-arguments",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "case",
+    _SECTION_NAME_CASES,
+    ids=[c.test_id for c in _SECTION_NAME_CASES],
+)
+def test_section_names_match_ids(case: SectionNameCase) -> None:
+    """``section["names"]`` mirrors ``section["ids"]`` under every prefix mode.
+
+    This is the core property the fix guarantees: the implicit hyperlink
+    target docutils derives from ``section["names"]`` carries the same
+    scoping that ``section["ids"]`` already had.
+    """
+    section = case.make_section(case.id_prefix)
+    assert section["ids"] == [case.expected_id]
+    assert section["names"] == [case.expected_id]
+
+
+class CollisionCase(t.NamedTuple):
+    """Inputs for one two-page cross-collision assertion."""
+
+    test_id: str
+    make_section: t.Callable[[str], nodes.section]
+
+
+_COLLISION_CASES: list[CollisionCase] = [
+    CollisionCase(test_id="usage-sections", make_section=_render_usage),
+    CollisionCase(test_id="group-sections", make_section=_render_group),
+]
+
+
+@pytest.mark.parametrize(
+    "case",
+    _COLLISION_CASES,
+    ids=[c.test_id for c in _COLLISION_CASES],
+)
+def test_multi_page_sections_do_not_collide(case: CollisionCase) -> None:
+    """Two pages emitting the same helper must produce disjoint targets.
+
+    This is derivable from :func:`test_section_names_match_ids`, but asserting
+    it directly documents the regression-test intent and gives a clearer
+    failure mode when the fix regresses.
+    """
+    page_a = case.make_section("page-a")
+    page_b = case.make_section("page-b")
     assert set(page_a["names"]).isdisjoint(page_b["names"])
     assert set(page_a["ids"]).isdisjoint(page_b["ids"])

--- a/tests/ext/argparse_neo/test_renderer_section_names.py
+++ b/tests/ext/argparse_neo/test_renderer_section_names.py
@@ -1,0 +1,106 @@
+"""Regression tests for section ``names`` scoping in the argparse_neo renderer.
+
+Prior to the fix, ``render_usage_section`` and ``render_group_section``
+correctly namespaced ``section["ids"]`` by the caller-supplied ``id_prefix``
+but left ``section["names"]`` unscoped. docutils converts ``names`` into
+implicit hyperlink targets, so multi-page docs using ``.. argparse::`` on
+more than one page collided on ``usage`` / ``options`` / ``positional
+arguments``, producing one ``duplicate label`` warning per collision. See
+https://github.com/git-pull/gp-sphinx/issues/15.
+"""
+
+from __future__ import annotations
+
+from sphinx_argparse_neo.parser import (
+    ArgumentGroup,
+    ArgumentInfo,
+    ParserInfo,
+)
+from sphinx_argparse_neo.renderer import ArgparseRenderer
+
+
+def _make_parser_info() -> ParserInfo:
+    return ParserInfo(
+        prog="myapp",
+        usage=None,
+        bare_usage="myapp [-h]",
+        description=None,
+        epilog=None,
+        argument_groups=[],
+        subcommands=None,
+        subcommand_dest=None,
+    )
+
+
+def _make_positional_group() -> ArgumentGroup:
+    return ArgumentGroup(
+        title="positional arguments",
+        description=None,
+        arguments=[
+            ArgumentInfo(
+                names=["filename"],
+                help="Input file",
+                default=None,
+                default_string="None",
+                choices=None,
+                required=True,
+                metavar=None,
+                nargs=None,
+                action="store",
+                type_name=None,
+                const=None,
+                dest="filename",
+            ),
+        ],
+        mutually_exclusive=[],
+    )
+
+
+def test_usage_section_names_match_ids_without_prefix() -> None:
+    """Without a prefix, usage section ``names`` equal its ``ids``."""
+    section = ArgparseRenderer().render_usage_section(_make_parser_info())
+    assert section["ids"] == ["usage"]
+    assert section["names"] == ["usage"]
+
+
+def test_usage_section_names_match_ids_with_prefix() -> None:
+    """With a prefix, usage section ``names`` are scoped the same as ``ids``."""
+    section = ArgparseRenderer().render_usage_section(
+        _make_parser_info(), id_prefix="load"
+    )
+    assert section["ids"] == ["load-usage"]
+    assert section["names"] == ["load-usage"]
+
+
+def test_group_section_names_match_ids_without_prefix() -> None:
+    """Without a prefix, group section ``names`` equal its ``ids``."""
+    section = ArgparseRenderer().render_group_section(_make_positional_group())
+    assert section["ids"] == ["positional-arguments"]
+    assert section["names"] == ["positional-arguments"]
+
+
+def test_group_section_names_match_ids_with_prefix() -> None:
+    """With a prefix, group section ``names`` are scoped the same as ``ids``."""
+    section = ArgparseRenderer().render_group_section(
+        _make_positional_group(), id_prefix="load"
+    )
+    assert section["ids"] == ["load-positional-arguments"]
+    assert section["names"] == ["load-positional-arguments"]
+
+
+def test_multi_page_usage_sections_do_not_collide() -> None:
+    """Two pages' usage sections must produce disjoint implicit targets."""
+    renderer = ArgparseRenderer()
+    page_a = renderer.render_usage_section(_make_parser_info(), id_prefix="page-a")
+    page_b = renderer.render_usage_section(_make_parser_info(), id_prefix="page-b")
+    assert set(page_a["names"]).isdisjoint(page_b["names"])
+    assert set(page_a["ids"]).isdisjoint(page_b["ids"])
+
+
+def test_multi_page_group_sections_do_not_collide() -> None:
+    """Two pages' group sections must produce disjoint implicit targets."""
+    renderer = ArgparseRenderer()
+    page_a = renderer.render_group_section(_make_positional_group(), id_prefix="page-a")
+    page_b = renderer.render_group_section(_make_positional_group(), id_prefix="page-b")
+    assert set(page_a["names"]).isdisjoint(page_b["names"])
+    assert set(page_a["ids"]).isdisjoint(page_b["ids"])


### PR DESCRIPTION
## Summary

- Mirror `section["ids"]` into `section["names"]` in `render_usage_section`, `render_group_section`, and `_create_example_section` so multi-page MyST docs that embed `.. argparse::` via `{eval-rst}` no longer emit `duplicate label` warnings for shared implicit targets (`usage`, `options`, `positional arguments`, `examples`).
- Add a MyST-based integration test and six unit tests that fail against `main` and pass against this branch.

Fixes #15.

## Root cause

`render_usage_section`, `render_group_section`, and `_create_example_section` were correctly namespacing `section["ids"]` by the caller-supplied `id_prefix` but hard-coded the unprefixed title into `section["names"]`:

```python
section["ids"] = [section_id]                                # "add-usage"
section["names"] = [nodes.fully_normalize_name("Usage")]     # "usage"  -- BUG
```

docutils turns `section["names"]` into implicit hyperlink targets. On plain-RST pages those stay implicit and Sphinx's std domain silently dedupes them. But downstream consumers (vcspull, tmuxp, libtmux, libvcs, …) wire their CLI docs through **MyST `{eval-rst}` blocks**, which promote the nested RST section names to *explicit* cross-document targets. At that point Sphinx's `std.process_doc` (`sphinx/domains/std/__init__.py:936-964`) iterates `document.nametypes.items()`, `continue`s on implicit names, and logs `duplicate label <name>, other instance in …` for every collision of explicit names.

Result: every CLI page on vcspull `api-styling` produced one warning per shared section (`usage`, `options`, `positional arguments`), totalling 71 lines in a full build.

## Fix

Propagate `id_prefix` into `section["names"]` just like it already flows into `section["ids"]`. The fix is a one-line change at each of three call sites — unit tests demonstrate that `section["names"] == section["ids"]` is now maintained under every combination of with/without prefix.

## Test plan

- `uv run ruff check . --fix --show-fixes` — all checks passed
- `uv run ruff format .` — 110 files unchanged
- `uv run mypy` — no issues found in 105 source files
- `uv run py.test --reruns 0 -q` — **783 passed, 3 skipped** (776 baseline + 7 new)
- `just build-docs` — build succeeded, no new warnings

Regression coverage, verified by locally reverting the two source commits:
- `tests/ext/argparse_neo/test_renderer_section_names.py` — 5 of 6 unit tests fail on the old code (the sixth is a no-prefix baseline that happened to match trivially)
- `tests/ext/argparse_neo/test_multi_page_integration.py` — fails with three duplicate-label lines (`usage`, `positional arguments`, `options`); the test builds a synthetic MyST two-page project exactly mirroring the vcspull wiring pattern

## Downstream impact

Thirteen repositories are currently on `api-styling` branches consuming gp-sphinx 0.0.1a5/0.0.1a6. After this PR is merged and a new prerelease is cut, each of them gets a clean duplicate-label-free docs build via a single pin bump:

- cihai/cihai #396
- cihai/cihai-cli #346
- cihai/unihan-db #362
- cihai/unihan-etl #354
- tmux-python/libtmux #658
- tmux-python/tmuxp #1035
- tmux-python/libtmux-mcp #10
- vcs-python/libvcs #522
- vcs-python/vcspull #542
- vcs-python/g #53
- git-pull/gp-libs #67
- tony/django-docutils #453
- tony/django-slugify-processor #417

## Out of scope

vcspull's `api-styling` build also produces 39 `ERROR/3: Unexpected indentation` lines during `reading sources...`. Those are **pre-existing on `master` in equal measure** — they originate in a priority-ordering bug in `sphinx_autodoc_typehints/patches.py:75` where `napoleon_numpy_docstring_return_type_processor` (registered at `priority=499`) runs before `process_docstring` (at `priority=500`), so typehints's own `_inject_rtype` ends up parsing a docstring that already contains its own `:` sentinel and docutils rejects the result. That belongs upstream at `tox-dev/sphinx-autodoc-typehints`, and since future gp-sphinx releases are planned to drop `sphinx.ext.napoleon` and `sphinx_autodoc_typehints` entirely, the noise will also disappear naturally — intentionally **not** addressed in this PR.

Scope comparison for `vcspull`:

| Metric                    | `master` | `api-styling` | Δ |
|---------------------------|---------:|---------------:|----:|
| `Unexpected indentation`  | 39       | 39             | 0   |
| `duplicate label`         | 64       | 71             | +7  |

This PR closes the `+7` regression (and also zeroes out the pre-existing 64 as a bonus).

## Draft rationale

Marked as draft pending (a) CI validation across the supported Sphinx/Python matrix and (b) coordinated release + pin-bump across the 13 downstream repos listed above.