### PR TITLE
theme(fix[spa-nav]): fragment scroll + copy-button recreation

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -65,6 +65,14 @@ $ uv add gp-sphinx --prerelease allow
 
 ### Bug fixes
 
+- `sphinx-gp-theme`: SPA nav now scrolls to the target anchor on
+  cross-page fragment links. `document.querySelector(hash)` mis-parses
+  any hash containing `.` (e.g. Python autodoc IDs like
+  `#libtmux_mcp.models.SearchPanesResult`) as a CSS class selector, so
+  every `py:class` / `py:meth` / `py:attr` cross-ref was failing to
+  scroll. Switched to `getElementById(decodeURIComponent(hash.slice(1)))`
+  and moved the scroll-to-fragment branch out of the `!isPop` guard so
+  browser forward/back also scrolls to fragments (#20)
 - Load full weight range `[300, 400, 500, 600, 700]` for both IBM Plex
   Sans and IBM Plex Mono (badges render in monospace at `font-weight: 700`,
   Furo code blocks use 300, and intermediate weights inherit from

--- a/CHANGES
+++ b/CHANGES
@@ -77,7 +77,10 @@ $ uv add gp-sphinx --prerelease allow
   template instead of cloning ``.copybtn`` from the initial page.
   Pages without code blocks (landing pages, prose-only indexes) left
   ``copyBtnTemplate`` null, so SPA-navigating to a code-block page
-  produced no copy affordance. `gp_sphinx` also injects a small
+  produced no copy affordance. The inline template is byte-equivalent
+  to sphinx-copybutton's output — same classes, same SVG with
+  ``<title>Copy to clipboard</title>`` so screen readers announce the
+  button correctly. `gp_sphinx` also injects a small
   ``window.GP_SPHINX_COPYBUTTON_SELECTOR`` bridge from the project's
   configured ``copybutton_selector`` via ``html-page-context``, so
   projects that extend the selector (e.g. prompt admonitions) get

--- a/CHANGES
+++ b/CHANGES
@@ -73,6 +73,16 @@ $ uv add gp-sphinx --prerelease allow
   scroll. Switched to `getElementById(decodeURIComponent(hash.slice(1)))`
   and moved the scroll-to-fragment branch out of the `!isPop` guard so
   browser forward/back also scrolls to fragments (#20)
+- `sphinx-gp-theme`: SPA nav re-creates copy buttons from an inline
+  template instead of cloning ``.copybtn`` from the initial page.
+  Pages without code blocks (landing pages, prose-only indexes) left
+  ``copyBtnTemplate`` null, so SPA-navigating to a code-block page
+  produced no copy affordance. `gp_sphinx` also injects a small
+  ``window.GP_SPHINX_COPYBUTTON_SELECTOR`` bridge from the project's
+  configured ``copybutton_selector`` via ``html-page-context``, so
+  projects that extend the selector (e.g. prompt admonitions) get
+  copy buttons re-applied to every configured match after SPA swap,
+  not just to code blocks (#20)
 - Load full weight range `[300, 400, 500, 600, 700]` for both IBM Plex
   Sans and IBM Plex Mono (badges render in monospace at `font-weight: 700`,
   Furo code blocks use 300, and intermediate weights inherit from

--- a/packages/gp-sphinx/src/gp_sphinx/config.py
+++ b/packages/gp-sphinx/src/gp_sphinx/config.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import contextlib
 import copy
 import inspect
+import json
 import logging
 import os.path
 import pathlib
@@ -460,11 +461,53 @@ def remove_tabs_js(app: Sphinx, exc: Exception | None) -> None:
             tabs_js.unlink()
 
 
+def _inject_copybutton_bridge(
+    app: Sphinx,
+    pagename: str,
+    templatename: str,
+    context: dict[str, t.Any],
+    doctree: object,
+) -> None:
+    """Expose ``copybutton_selector`` to ``spa-nav.js`` as a window global.
+
+    ``sphinx-copybutton`` bakes its selector into ``copybutton.js`` at build
+    time inside a function-local ``const``, so it is not reachable from
+    outside JS. ``spa-nav.js`` needs the selector at runtime to re-create
+    copy buttons after SPA swaps on pages whose selectors include more than
+    the default ``div.highlight pre`` (e.g. custom prompt admonitions).
+
+    This hook emits a small inline script into ``<head>`` that sets
+    ``window.GP_SPHINX_COPYBUTTON_SELECTOR`` from the project's configured
+    ``copybutton_selector``.
+
+    Parameters
+    ----------
+    app : Sphinx
+        The Sphinx application object.
+    pagename : str
+        Name of the page being rendered.
+    templatename : str
+        Name of the template being used.
+    context : dict[str, Any]
+        Rendering context passed to the template.
+    doctree : object
+        Doctree for the page (unused).
+    """
+    if "sphinx_copybutton" not in app.config.extensions:
+        return
+    selector = getattr(app.config, "copybutton_selector", "div.highlight pre")
+    snippet = (
+        f"<script>window.GP_SPHINX_COPYBUTTON_SELECTOR={json.dumps(selector)};</script>"
+    )
+    context["metatags"] = context.get("metatags", "") + snippet
+
+
 def setup(app: Sphinx) -> None:
     """Configure Sphinx app hooks for gp-sphinx workarounds.
 
-    Registers the bundled ``spa-nav.js`` script and connects the
-    ``remove_tabs_js`` post-build hook.
+    Registers the bundled ``spa-nav.js`` script, wires the copy-button
+    configuration bridge, and connects the ``remove_tabs_js`` post-build
+    hook.
 
     Parameters
     ----------
@@ -472,6 +515,7 @@ def setup(app: Sphinx) -> None:
         The Sphinx application object.
     """
     app.add_js_file("js/spa-nav.js", loading_method="defer")
+    app.connect("html-page-context", _inject_copybutton_bridge)
     app.connect("build-finished", remove_tabs_js)
     app.add_lexer("myst", MystLexer)
     app.add_lexer("myst-md", MystLexer)

--- a/packages/sphinx-gp-theme/src/sphinx_gp_theme/theme/static/js/spa-nav.js
+++ b/packages/sphinx-gp-theme/src/sphinx_gp_theme/theme/static/js/spa-nav.js
@@ -26,27 +26,56 @@
   }
 
   // --- Copy button injection ---
+  //
+  // Matches sphinx-copybutton's button HTML (copybutton.js_t:141-145 and
+  // the default icon at copybutton.js_t:70-75) so SPA-inserted buttons
+  // look identical to initially-rendered ones and plug into ClipboardJS's
+  // body-delegated listener transparently.
+  //
+  // Uses an inline template instead of cloning an existing ``.copybtn``:
+  // a landing page may have no code blocks (and therefore no button to
+  // clone), which previously left ``copyBtnTemplate`` null on every
+  // subsequent SPA-swapped page.
+  //
+  // Reads ``window.GP_SPHINX_COPYBUTTON_SELECTOR`` — set by gp-sphinx's
+  // ``html-page-context`` hook from the project's configured
+  // ``copybutton_selector`` — so projects that extend the selector (e.g.
+  // ``"div.highlight pre, div.admonition.prompt > p:last-child"``) get
+  // copy buttons re-applied to every matching element on SPA navigation,
+  // not just to code blocks.
 
-  var copyBtnTemplate = null;
+  var iconCopy =
+    '<svg xmlns="http://www.w3.org/2000/svg" ' +
+    'class="icon icon-tabler icon-tabler-copy" ' +
+    'width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" ' +
+    'stroke="#000000" fill="none" stroke-linecap="round" ' +
+    'stroke-linejoin="round">' +
+    '<path stroke="none" d="M0 0h24v24H0z" fill="none"/>' +
+    '<rect x="8" y="8" width="12" height="12" rx="2" />' +
+    '<path d="M16 8v-2a2 2 0 0 0 -2 -2h-8a2 2 0 0 0 -2 2v8a2 2 0 0 0 2 2h2" />' +
+    "</svg>";
 
-  function captureCopyIcon() {
-    var btn = document.querySelector(".copybtn");
-    if (btn) copyBtnTemplate = btn.cloneNode(true);
+  function makeCopyButton(targetId) {
+    return (
+      '<button class="copybtn o-tooltip--left" data-tooltip="Copy" ' +
+      'data-clipboard-target="#' + targetId + '">' +
+      iconCopy +
+      "</button>"
+    );
   }
 
   function addCopyButtons() {
-    if (!copyBtnTemplate) captureCopyIcon();
-    if (!copyBtnTemplate) return;
-    var cells = document.querySelectorAll("div.highlight pre");
+    var selector =
+      window.GP_SPHINX_COPYBUTTON_SELECTOR || "div.highlight pre";
+    var cells = document.querySelectorAll(selector);
     cells.forEach(function (cell, i) {
-      cell.id = "codecell" + i;
+      var id = "codecell" + i;
+      cell.id = id;
       var next = cell.nextElementSibling;
       if (next && next.classList.contains("copybtn")) {
-        next.setAttribute("data-clipboard-target", "#codecell" + i);
+        next.setAttribute("data-clipboard-target", "#" + id);
       } else {
-        var btn = copyBtnTemplate.cloneNode(true);
-        btn.setAttribute("data-clipboard-target", "#codecell" + i);
-        cell.insertAdjacentElement("afterend", btn);
+        cell.insertAdjacentHTML("afterend", makeCopyButton(id));
       }
     });
   }
@@ -247,8 +276,7 @@
 
   // --- Init ---
 
-  // Copy buttons are injected by copybutton.js on DOMContentLoaded.
-  // This defer script runs before DOMContentLoaded, so our handler
-  // fires after copybutton's handler (registration order preserved).
-  document.addEventListener("DOMContentLoaded", captureCopyIcon);
+  // sphinx-copybutton creates the initial buttons on DOMContentLoaded.
+  // On SPA swap, ``addCopyButtons`` (called from ``reinit``) re-creates
+  // them from an inline template — no capture step is needed.
 })();

--- a/packages/sphinx-gp-theme/src/sphinx_gp_theme/theme/static/js/spa-nav.js
+++ b/packages/sphinx-gp-theme/src/sphinx_gp_theme/theme/static/js/spa-nav.js
@@ -183,14 +183,14 @@
 
         if (!isPop) history.pushState({ spa: true }, "", url);
 
-        if (!isPop) {
-          var hash = new URL(url, location.href).hash;
-          if (hash) {
-            var el = document.querySelector(hash);
-            if (el) el.scrollIntoView();
-          } else {
-            window.scrollTo(0, 0);
-          }
+        var hash = new URL(url, location.href).hash;
+        if (hash) {
+          var el = document.getElementById(
+            decodeURIComponent(hash.slice(1)),
+          );
+          if (el) el.scrollIntoView();
+        } else if (!isPop) {
+          window.scrollTo(0, 0);
         }
 
         reinit();

--- a/packages/sphinx-gp-theme/src/sphinx_gp_theme/theme/static/js/spa-nav.js
+++ b/packages/sphinx-gp-theme/src/sphinx_gp_theme/theme/static/js/spa-nav.js
@@ -50,6 +50,7 @@
     'width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" ' +
     'stroke="#000000" fill="none" stroke-linecap="round" ' +
     'stroke-linejoin="round">' +
+    "<title>Copy to clipboard</title>" +
     '<path stroke="none" d="M0 0h24v24H0z" fill="none"/>' +
     '<rect x="8" y="8" width="12" height="12" rx="2" />' +
     '<path d="M16 8v-2a2 2 0 0 0 -2 -2h-8a2 2 0 0 0 -2 2v8a2 2 0 0 0 2 2h2" />' +


### PR DESCRIPTION
Fixes #19 (fragment scroll). Also folds in two related SPA-nav defects surfaced while testing the scroll fix end-to-end.

## Bugs fixed

### 1. Cross-page fragment links don't scroll to anchor

**`document.querySelector(hash)` mis-parses dotted IDs.** Python autodoc anchors like `#libtmux_mcp.models.SearchPanesResult` read as *id `libtmux_mcp`* AND *class `models`* AND *class `SearchPanesResult`* — never match. Every `py:class` / `py:meth` / `py:attr` cross-ref silently failed to scroll.

**Scroll gated behind `!isPop`.** The `popstate` listener calls `navigate(..., true)`, so browser back/forward to a fragment URL never scrolled. gp-sphinx's own fetch+swap bypasses browser-native scroll restoration.

### 2. Copy buttons disappear after SPA swap from a page with no `.copybtn`

`addCopyButtons` cloned an existing `.copybtn` as its template. Landing pages and prose-only indexes have no code blocks, so `copyBtnTemplate` stayed null forever. SPA-navigating to any code-block page from there rendered without copy buttons.

### 3. Copy buttons only re-applied to `div.highlight pre`

`addCopyButtons` hard-coded that selector, ignoring whatever the project configured via `copybutton_selector` (e.g. prompt admonitions). Projects using custom selectors lost those copy affordances on every SPA swap.

## Fix

**`packages/sphinx-gp-theme/src/sphinx_gp_theme/theme/static/js/spa-nav.js`**:

- Scroll: `querySelector(hash)` → `getElementById(decodeURIComponent(hash.slice(1)))`; hash branch moved out of `!isPop` guard so popstate with fragment scrolls.
- Copy buttons: inline HTML template matching sphinx-copybutton's output verbatim (same classes, same SVG). Initial page no longer needs any `.copybtn` for SPA to work.
- Copy buttons: iterate `window.GP_SPHINX_COPYBUTTON_SELECTOR || "div.highlight pre"` so project-configured selectors are respected.

**`packages/gp-sphinx/src/gp_sphinx/config.py`**:

- New `_inject_copybutton_bridge` on `html-page-context`. Emits a small inline `<script>window.GP_SPHINX_COPYBUTTON_SELECTOR=…;</script>` from the project's `copybutton_selector` config. Gated on `sphinx_copybutton` being loaded.

## Verification

Tested end-to-end against libtmux-mcp docs at `localhost:8024` via Playwright MCP. libtmux-mcp configures `copybutton_selector = "div.highlight pre, div.admonition.prompt > p:last-child"` — it's a good test bed since it exercises both the fragment-scroll path and the extended-selector path.

| Scenario | Result |
|---|---|
| SPA click → URL with `#libtmux_mcp.models.SearchPanesResult` | `scrollY=9268`, at anchor |
| Browser forward (popstate) → same fragment URL | `scrollY=9268`, at anchor |
| SPA click → fragment-less URL | `scrollY=0`, scrolled to top |
| Landing `/` (no code blocks) → SPA-nav to `/installation/` | 11/11 `<pre>` get copy buttons |
| Landing `/` → SPA-nav to `/recipes/` (prompts only) | 8/8 prompt admonitions get copy buttons |
| Inline-generated button SVG class | `icon-tabler-copy` (matches sphinx-copybutton) |

Obsoletes libtmux-mcp's `docs/_static/js/spa-copybutton-reinit.js` shim, which was a project-local workaround for Bugs 2 and 3. That shim is being removed in a follow-up commit in libtmux-mcp.

## Test plan

- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run mypy`
- [x] `uv run pytest` — all tests pass
- [x] Manual: Playwright verification across all six scroll + copybutton scenarios above
- [ ] Reviewer sanity: open any gp-sphinx Python docs site whose landing page has no code blocks; SPA-nav to a code-block page and a prompt-admonition page; confirm copy buttons appear

## Out of scope

- `copybutton_image_svg` config override — we hard-code sphinx-copybutton's default SVG. Projects that override the icon get the default SVG on SPA-swapped buttons until the initial sphinx-copybutton run repaints (which it won't, since it only runs on DOMContentLoaded). Acceptable for now.
- i18n tooltip — we hard-code `"Copy"` instead of sphinx-copybutton's `{{ messages[locale]['copy'] }}`. Non-English docs get English tooltips on SPA-swapped buttons. Acceptable for now; can be bridged later.
- No JS test harness in this repo; fix lacks a regression test. Adding one is a worthwhile follow-up but intentionally deferred.