### PR TITLE
Pair gp-sphinx-light with monokai for proper light/dark code blocks

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,25 @@ $ uv add gp-sphinx --prerelease allow
 
 <!-- To maintainers and contributors: Please add notes for the forthcoming version below -->
 
+### What's new
+
+#### `sphinx-gp-theme`: Light-mode code blocks now render with a light palette
+
+Light mode previously fell back to monokai-on-light because both
+Furo Pygments slots defaulted to monokai. The theme now ships
+`gp-sphinx-light` (a CodeMirror-derived light palette) and pairs it
+with monokai under `body[data-theme="dark"]`, so both modes pick up
+appropriate code-block colors out of the box. (#24)
+
+### Bug fixes
+
+#### `sphinx-gp-theme`: argparse directives now follow the active theme
+
+`.. argparse::` blocks hardcoded a One Dark palette and rendered
+dark-on-light in light mode. Token colors now flow through
+`--gp-sphinx-argparse-*` custom properties with light defaults and
+dark overrides scoped to `body[data-theme="dark"]`. (#24)
+
 ## gp-sphinx 0.0.1a12 (2026-04-27)
 
 ### Bug fixes

--- a/packages/gp-sphinx/src/gp_sphinx/defaults.py
+++ b/packages/gp-sphinx/src/gp_sphinx/defaults.py
@@ -184,11 +184,22 @@ Examples
 ['_templates']
 """
 
-DEFAULT_PYGMENTS_STYLE: str = "monokai"
-"""Default Pygments syntax highlighting style."""
+DEFAULT_PYGMENTS_STYLE: str = "gp-sphinx-light"
+"""Default Pygments style applied in Furo's light mode.
+
+Resolves to :class:`sphinx_gp_theme.pygments_styles.GpSphinxLightStyle`
+via the ``pygments.styles`` entry point shipped by ``sphinx-gp-theme``.
+The palette mirrors the Microviz CodeMirror light theme.
+"""
 
 DEFAULT_PYGMENTS_DARK_STYLE: str = "monokai"
-"""Default Pygments syntax highlighting style for dark mode."""
+"""Default Pygments style applied in Furo's dark mode.
+
+Furo combines :data:`DEFAULT_PYGMENTS_STYLE` and this value into a single
+``pygments.css`` whose dark rules are scoped under
+``body[data-theme="dark"] .highlight``. ``monokai`` is kept here because it
+is the long-standing dark-mode appearance for git-pull project docs.
+"""
 
 DEFAULT_SPHINX_FONTS: list[FontConfig] = [
     {

--- a/packages/sphinx-gp-theme/pyproject.toml
+++ b/packages/sphinx-gp-theme/pyproject.toml
@@ -33,6 +33,9 @@ dependencies = [
 [project.entry-points."sphinx.html_themes"]
 "sphinx-gp-theme" = "sphinx_gp_theme"
 
+[project.entry-points."pygments.styles"]
+"gp-sphinx-light" = "sphinx_gp_theme.pygments_styles:GpSphinxLightStyle"
+
 [project.urls]
 Repository = "https://github.com/git-pull/gp-sphinx"
 

--- a/packages/sphinx-gp-theme/src/sphinx_gp_theme/pygments_styles.py
+++ b/packages/sphinx-gp-theme/src/sphinx_gp_theme/pygments_styles.py
@@ -1,0 +1,141 @@
+"""Pygments styles bundled with sphinx-gp-theme.
+
+Defines :class:`GpSphinxLightStyle`, a light syntax-highlighting style derived
+from the CodeMirror light palette used by the Microviz design system. The
+style is registered through the ``pygments.styles`` entry point declared in
+``pyproject.toml``, which makes it discoverable as ``"gp-sphinx-light"`` via
+:func:`pygments.styles.get_style_by_name`.
+
+Furo emits a single combined ``pygments.css`` whose unscoped rules apply in
+light mode and whose ``body[data-theme="dark"]``-scoped rules apply in dark
+mode, so pairing this light style with a dark Pygments style (e.g. ``monokai``)
+is enough to render distinct light- and dark-mode code blocks.
+
+Examples
+--------
+>>> from pygments.styles import get_style_by_name
+>>> style = get_style_by_name("gp-sphinx-light")
+>>> style.background_color
+'#f8fafc'
+>>> style.__name__
+'GpSphinxLightStyle'
+"""
+
+from __future__ import annotations
+
+import typing as t
+
+from pygments import style, token
+
+__all__ = ["GpSphinxLightStyle"]
+
+
+class GpSphinxLightStyle(style.Style):
+    """Light Pygments style mirroring the Microviz CodeMirror light palette.
+
+    The token-to-color mapping follows the OKLCH-derived palette used by the
+    CodeMirror editor in ``social-embed`` and ``microviz``: slate-900 text on
+    a slate-50 background, with purple keywords, yellow strings, blue numbers,
+    orange built-ins, red HTML tags, and slate-500 italic comments.
+
+    Examples
+    --------
+    >>> GpSphinxLightStyle.name
+    'gp-sphinx-light'
+    >>> GpSphinxLightStyle.background_color
+    '#f8fafc'
+    >>> GpSphinxLightStyle.styles[token.Keyword]
+    'bold #7c3aed'
+    >>> GpSphinxLightStyle.styles[token.String]
+    '#ca8a04'
+    >>> GpSphinxLightStyle.styles[token.Comment]
+    'italic #64748b'
+    """
+
+    name = "gp-sphinx-light"
+
+    background_color = "#f8fafc"
+    highlight_color = "#dbeafe"
+    line_number_color = "#64748b"
+    line_number_background_color = "#f1f5f9"
+    line_number_special_color = "#0f172a"
+    line_number_special_background_color = "#dbeafe"
+
+    styles: t.ClassVar[dict[token._TokenType, str]] = {
+        token.Whitespace: "#cbd5e1",
+        token.Text: "#0f172a",
+        token.Error: "border:#dc2626 #dc2626",
+        token.Other: "#0f172a",
+        token.Comment: "italic #64748b",
+        token.Comment.Hashbang: "italic #64748b",
+        token.Comment.Multiline: "italic #64748b",
+        token.Comment.Preproc: "noitalic #7c3aed",
+        token.Comment.PreprocFile: "noitalic #ca8a04",
+        token.Comment.Single: "italic #64748b",
+        token.Comment.Special: "italic bold #64748b",
+        token.Keyword: "bold #7c3aed",
+        token.Keyword.Constant: "bold #ea580c",
+        token.Keyword.Declaration: "bold #7c3aed",
+        token.Keyword.Namespace: "bold #7c3aed",
+        token.Keyword.Pseudo: "nobold #7c3aed",
+        token.Keyword.Reserved: "bold #7c3aed",
+        token.Keyword.Type: "nobold #a855f7",
+        token.Operator: "#0f172a",
+        token.Operator.Word: "bold #7c3aed",
+        token.Punctuation: "#0f172a",
+        token.Name: "#0f172a",
+        token.Name.Attribute: "#a855f7",
+        token.Name.Builtin: "#ea580c",
+        token.Name.Builtin.Pseudo: "#ea580c",
+        token.Name.Class: "bold #0f172a",
+        token.Name.Constant: "#ea580c",
+        token.Name.Decorator: "#a855f7",
+        token.Name.Entity: "bold #dc2626",
+        token.Name.Exception: "bold #dc2626",
+        token.Name.Function: "#0f172a",
+        token.Name.Function.Magic: "#a855f7",
+        token.Name.Label: "#475569",
+        token.Name.Namespace: "bold #0f172a",
+        token.Name.Other: "#0f172a",
+        token.Name.Tag: "#dc2626",
+        token.Name.Variable: "#0f172a",
+        token.Name.Variable.Class: "#0f172a",
+        token.Name.Variable.Global: "#0f172a",
+        token.Name.Variable.Instance: "#0f172a",
+        token.Name.Variable.Magic: "#a855f7",
+        token.Number: "#3b82f6",
+        token.Number.Bin: "#3b82f6",
+        token.Number.Float: "#3b82f6",
+        token.Number.Hex: "#3b82f6",
+        token.Number.Integer: "#3b82f6",
+        token.Number.Integer.Long: "#3b82f6",
+        token.Number.Oct: "#3b82f6",
+        token.Literal: "#0f172a",
+        token.Literal.Date: "#ca8a04",
+        token.String: "#ca8a04",
+        token.String.Affix: "bold #ca8a04",
+        token.String.Backtick: "#ca8a04",
+        token.String.Char: "#ca8a04",
+        token.String.Delimiter: "#ca8a04",
+        token.String.Doc: "italic #64748b",
+        token.String.Double: "#ca8a04",
+        token.String.Escape: "bold #b45309",
+        token.String.Heredoc: "#ca8a04",
+        token.String.Interpol: "bold #b45309",
+        token.String.Other: "#ca8a04",
+        token.String.Regex: "#ea580c",
+        token.String.Single: "#ca8a04",
+        token.String.Symbol: "#ca8a04",
+        token.Generic: "#0f172a",
+        token.Generic.Deleted: "#dc2626",
+        token.Generic.Emph: "italic",
+        token.Generic.Error: "#dc2626",
+        token.Generic.Heading: "bold #0f172a",
+        token.Generic.Inserted: "#16a34a",
+        token.Generic.Output: "#475569",
+        token.Generic.Prompt: "bold #475569",
+        token.Generic.Strong: "bold",
+        token.Generic.EmphStrong: "bold italic",
+        token.Generic.Subheading: "bold #475569",
+        token.Generic.Traceback: "#dc2626",
+    }

--- a/packages/sphinx-gp-theme/src/sphinx_gp_theme/theme/static/css/argparse-highlight.css
+++ b/packages/sphinx-gp-theme/src/sphinx_gp_theme/theme/static/css/argparse-highlight.css
@@ -2,20 +2,94 @@
  * Argparse/CLI Highlighting Styles
  *
  * Styles for CLI inline roles and argparse help output highlighting.
- * Uses "One Dark" inspired color palette (Python 3.14 argparse style).
+ * Two parallel palettes are exposed via custom properties:
  *
- * Color Palette:
- *   Background:    #282C34
- *   Default text:  #CCCED4
- *   Usage label:   #61AFEF (blue, bold)
- *   Program name:  #C678DD (purple, bold)
- *   Subcommands:   #98C379 (green)
- *   Options:       #56B6C2 (teal)
- *   Metavars:      #E5C07B (yellow, italic)
- *   Choices:       #98C379 (green)
- *   Headings:      #E5E5E5 (bright, bold)
- *   Punctuation:   #CCCED4
+ *   - Light mode (default)  : CodeMirror light palette (Microviz / social-embed).
+ *   - Dark mode (overrides) : "One Dark" inspired palette (the historic
+ *                             Python 3.14 argparse style).
+ *
+ * Dark overrides follow Furo's scoping convention: applied under
+ * `body[data-theme="dark"]` and inside
+ * `@media (prefers-color-scheme: dark) { body:not([data-theme="light"]) … }`,
+ * so theme switches and the OS-level "auto" mode both Just Work.
+ *
+ * Token role -> Custom property:
+ *   Code background       --gp-sphinx-argparse-code-bg
+ *   Default text          --gp-sphinx-argparse-text
+ *   Usage label           --gp-sphinx-argparse-usage-label   (bold)
+ *   Section heading       --gp-sphinx-argparse-section       (bold)
+ *   Program / command lbl --gp-sphinx-argparse-command       (bold)
+ *   Subcommand            --gp-sphinx-argparse-subcommand    (bold)
+ *   Choice value          --gp-sphinx-argparse-choice
+ *   Option flag (-h, --x) --gp-sphinx-argparse-option
+ *   Metavar (FILE, PATH)  --gp-sphinx-argparse-metavar       (italic)
+ *   Default value         --gp-sphinx-argparse-default       (italic)
+ *   Punctuation/operator  --gp-sphinx-argparse-punctuation
+ *   Meta tag bg / border  --gp-sphinx-argparse-meta-tag-bg / --…-meta-tag-border
  */
+
+/* ==========================================================================
+   Palette — light mode defaults
+   ========================================================================== */
+
+:root {
+	--gp-sphinx-argparse-code-bg: #f1f5f9;
+	--gp-sphinx-argparse-text: #0f172a;
+	--gp-sphinx-argparse-usage-label: #3b82f6;
+	--gp-sphinx-argparse-section: #0f172a;
+	--gp-sphinx-argparse-command: #7c3aed;
+	--gp-sphinx-argparse-subcommand: #16a34a;
+	--gp-sphinx-argparse-choice: #16a34a;
+	--gp-sphinx-argparse-option: #a855f7;
+	--gp-sphinx-argparse-metavar: #ca8a04;
+	--gp-sphinx-argparse-default: #64748b;
+	--gp-sphinx-argparse-punctuation: #64748b;
+	--gp-sphinx-argparse-meta-tag-bg: #fef3c780;
+	--gp-sphinx-argparse-meta-tag-border: #fcd34d80;
+	/*
+	 * Back-compat alias: pre.argparse-usage and .argparse-meta-value .nv
+	 * still reference --argparse-code-background in templates and snapshots.
+	 */
+	--argparse-code-background: var(--gp-sphinx-argparse-code-bg);
+}
+
+/* ==========================================================================
+   Palette — dark mode overrides (One Dark)
+   ========================================================================== */
+
+body[data-theme="dark"] {
+	--gp-sphinx-argparse-code-bg: #272822;
+	--gp-sphinx-argparse-text: #ccced4;
+	--gp-sphinx-argparse-usage-label: #61afef;
+	--gp-sphinx-argparse-section: #e5e5e5;
+	--gp-sphinx-argparse-command: #c678dd;
+	--gp-sphinx-argparse-subcommand: #98c379;
+	--gp-sphinx-argparse-choice: #98c379;
+	--gp-sphinx-argparse-option: #56b6c2;
+	--gp-sphinx-argparse-metavar: #e5c07b;
+	--gp-sphinx-argparse-default: #ccced4;
+	--gp-sphinx-argparse-punctuation: #ccced4;
+	--gp-sphinx-argparse-meta-tag-bg: #78350f60;
+	--gp-sphinx-argparse-meta-tag-border: #b4530980;
+}
+
+@media (prefers-color-scheme: dark) {
+	body:not([data-theme="light"]) {
+		--gp-sphinx-argparse-code-bg: #272822;
+		--gp-sphinx-argparse-text: #ccced4;
+		--gp-sphinx-argparse-usage-label: #61afef;
+		--gp-sphinx-argparse-section: #e5e5e5;
+		--gp-sphinx-argparse-command: #c678dd;
+		--gp-sphinx-argparse-subcommand: #98c379;
+		--gp-sphinx-argparse-choice: #98c379;
+		--gp-sphinx-argparse-option: #56b6c2;
+		--gp-sphinx-argparse-metavar: #e5c07b;
+		--gp-sphinx-argparse-default: #ccced4;
+		--gp-sphinx-argparse-punctuation: #ccced4;
+		--gp-sphinx-argparse-meta-tag-bg: #78350f60;
+		--gp-sphinx-argparse-meta-tag-border: #b4530980;
+	}
+}
 
 /* ==========================================================================
    Inline Role Styles
@@ -33,51 +107,32 @@
 	font-size: var(--code-font-size);
 }
 
-/*
- * CLI Options
- *
- * Long options (--verbose) and short options (-h) both use teal color.
- */
+/* Long options (--verbose) and short options (-h) */
 .cli-option-long,
 .cli-option-short {
-	color: #56b6c2;
+	color: var(--gp-sphinx-argparse-option);
 }
 
-/*
- * CLI Metavars
- *
- * Placeholder values like FILE, PATH, DIRECTORY.
- * Yellow/amber to indicate "replace me" - distinct from flags (teal).
- */
+/* Placeholder values like FILE, PATH, DIRECTORY */
 .cli-metavar {
-	color: #e5c07b;
+	color: var(--gp-sphinx-argparse-metavar);
 	font-style: italic;
 }
 
-/*
- * CLI Commands and Choices
- *
- * Both use green to indicate valid enumerated values.
- * Commands: subcommand names like sync, add, list
- * Choices: enumeration values like json, yaml, table
- */
-.cli-command,
-.cli-choice {
-	color: #98c379;
-}
-
+/* Subcommand names like sync, add, list */
 .cli-command {
+	color: var(--gp-sphinx-argparse-subcommand);
 	font-weight: bold;
 }
 
-/*
- * CLI Default Values
- *
- * Default values shown in help text like None, "auto".
- * Subtle styling to not distract from options.
- */
+/* Enumeration values like json, yaml, table */
+.cli-choice {
+	color: var(--gp-sphinx-argparse-choice);
+}
+
+/* Default values shown in help text like None, "auto" */
 .cli-default {
-	color: #ccced4;
+	color: var(--gp-sphinx-argparse-default);
 	font-style: italic;
 }
 
@@ -90,83 +145,83 @@
  * argparse, argparse-usage, or argparse-help lexers.
  */
 
-/* Usage heading "usage:" - bold blue */
+/* Usage heading "usage:" */
 .highlight-argparse .gh,
 .highlight-argparse-usage .gh,
 .highlight-argparse-help .gh {
-	color: #61afef;
+	color: var(--gp-sphinx-argparse-usage-label);
 	font-weight: bold;
 }
 
-/* Section headers like "positional arguments:", "options:" - neutral bright */
+/* Section headers like "positional arguments:", "options:" */
 .highlight-argparse .gs,
 .highlight-argparse-help .gs {
-	color: #e5e5e5;
+	color: var(--gp-sphinx-argparse-section);
 	font-weight: bold;
 }
 
-/* Long options --foo - teal */
+/* Long options --foo */
 .highlight-argparse .nt,
 .highlight-argparse-usage .nt,
 .highlight-argparse-help .nt {
-	color: #56b6c2;
+	color: var(--gp-sphinx-argparse-option);
 	font-weight: normal;
 }
 
-/* Short options -h - teal (same as long) */
+/* Short options -h */
 .highlight-argparse .na,
 .highlight-argparse-usage .na,
 .highlight-argparse-help .na {
-	color: #56b6c2;
+	color: var(--gp-sphinx-argparse-option);
 	font-weight: normal;
 }
 
-/* Metavar placeholders FILE, PATH - yellow/amber italic */
+/* Metavar placeholders FILE, PATH */
 .highlight-argparse .nv,
 .highlight-argparse-usage .nv,
 .highlight-argparse-help .nv {
-	color: #e5c07b;
+	color: var(--gp-sphinx-argparse-metavar);
 	font-style: italic;
 }
 
-/* Command/program names - purple bold */
+/* Command/program names */
 .highlight-argparse .nl,
 .highlight-argparse-usage .nl,
 .highlight-argparse-help .nl {
-	color: #c678dd;
+	color: var(--gp-sphinx-argparse-command);
 	font-weight: bold;
 }
 
-/* Subcommands - bold green */
+/* Subcommands */
 .highlight-argparse .nf,
 .highlight-argparse-usage .nf,
 .highlight-argparse-help .nf {
-	color: #98c379;
+	color: var(--gp-sphinx-argparse-subcommand);
 	font-weight: bold;
 }
 
-/* Choice values - green */
+/* Choice values */
 .highlight-argparse .no,
 .highlight-argparse-usage .no,
 .highlight-argparse-help .no,
 .highlight-argparse .nc,
 .highlight-argparse-usage .nc,
 .highlight-argparse-help .nc {
-	color: #98c379;
+	color: var(--gp-sphinx-argparse-choice);
 }
 
-/* Punctuation [], {}, () - neutral gray */
+/* Punctuation [], {}, () */
 .highlight-argparse .p,
 .highlight-argparse-usage .p,
 .highlight-argparse-help .p {
-	color: #ccced4;
+	color: var(--gp-sphinx-argparse-punctuation);
 }
 
-/* Operators like | - neutral gray */
+/* Operators like | */
 .highlight-argparse .o,
 .highlight-argparse-usage .o,
 .highlight-argparse-help .o {
-	color: #ccced4;
+	color: var(--gp-sphinx-argparse-punctuation);
 	font-weight: normal;
 }
 
@@ -175,23 +230,13 @@
    ========================================================================== */
 
 /*
- * These styles apply to the argparse directive output which uses custom
- * nodes rendered by sphinx_autodoc_argparse. The directive adds highlight spans
- * directly to the HTML output.
+ * These styles apply to the argparse directive output rendered by
+ * sphinx_autodoc_argparse, which adds highlight spans directly to HTML.
  */
 
-/*
- * Usage Block (.argparse-usage)
- *
- * The usage block now has both .argparse-usage and .highlight-argparse-usage
- * classes. The .highlight-argparse-usage selectors above already handle the
- * token highlighting. These selectors provide fallback and ensure consistent
- * styling.
- */
-
-/* Usage block container - match Pygments monokai background and code block styling */
+/* Usage block container */
 pre.argparse-usage {
-	background: var(--argparse-code-background);
+	background: var(--gp-sphinx-argparse-code-bg);
 	font-size: var(--code-font-size);
 	padding: 0.625rem 0.875rem;
 	line-height: 1.5;
@@ -201,47 +246,47 @@ pre.argparse-usage {
 }
 
 .argparse-usage .gh {
-	color: #61afef;
+	color: var(--gp-sphinx-argparse-usage-label);
 	font-weight: bold;
 }
 
 .argparse-usage .nt {
-	color: #56b6c2;
+	color: var(--gp-sphinx-argparse-option);
 	font-weight: normal;
 }
 
 .argparse-usage .na {
-	color: #56b6c2;
+	color: var(--gp-sphinx-argparse-option);
 	font-weight: normal;
 }
 
 .argparse-usage .nv {
-	color: #e5c07b;
+	color: var(--gp-sphinx-argparse-metavar);
 	font-style: italic;
 }
 
 .argparse-usage .nl {
-	color: #c678dd;
+	color: var(--gp-sphinx-argparse-command);
 	font-weight: bold;
 }
 
 .argparse-usage .nf {
-	color: #98c379;
+	color: var(--gp-sphinx-argparse-subcommand);
 	font-weight: bold;
 }
 
 .argparse-usage .no,
 .argparse-usage .nc {
-	color: #98c379;
+	color: var(--gp-sphinx-argparse-choice);
 }
 
 .argparse-usage .o {
-	color: #ccced4;
+	color: var(--gp-sphinx-argparse-punctuation);
 	font-weight: normal;
 }
 
 .argparse-usage .p {
-	color: #ccced4;
+	color: var(--gp-sphinx-argparse-punctuation);
 }
 
 /*
@@ -251,22 +296,22 @@ pre.argparse-usage {
  * semantic spans for options and metavars.
  */
 .argparse-argument-name .nt {
-	color: #56b6c2;
+	color: var(--gp-sphinx-argparse-option);
 	font-weight: normal;
 }
 
 .argparse-argument-name .na {
-	color: #56b6c2;
+	color: var(--gp-sphinx-argparse-option);
 	font-weight: normal;
 }
 
 .argparse-argument-name .nv {
-	color: #e5c07b;
+	color: var(--gp-sphinx-argparse-metavar);
 	font-style: italic;
 }
 
 .argparse-argument-name .nl {
-	color: #c678dd;
+	color: var(--gp-sphinx-argparse-command);
 	font-weight: bold;
 }
 
@@ -275,19 +320,11 @@ pre.argparse-usage {
    ========================================================================== */
 
 /*
- * Argparse-specific code background (monokai #272822)
- * Uses a custom variable to avoid affecting Furo's --color-inline-code-background.
- */
-:root {
-	--argparse-code-background: #272822;
-}
-
-/*
- * Background styling for argument names - subtle background like code.literal
- * This provides visual weight and hierarchy for argument definitions.
+ * Background styling for argument names — subtle background like code.literal
+ * to provide visual weight and hierarchy for argument definitions.
  */
 .argparse-argument-name {
-	background: var(--argparse-code-background);
+	background: var(--gp-sphinx-argparse-code-bg);
 	border-radius: 0.2rem;
 	padding: 0.485rem 0.875rem;
 	font-family: var(--font-stack--monospace);
@@ -297,7 +334,7 @@ pre.argparse-usage {
 }
 
 /*
- * Wrapper for linking - enables scroll-margin for fixed header navigation
+ * Wrapper for linking — enables scroll-margin for fixed header navigation
  * and :target pseudo-class for highlighting when linked.
  */
 .argparse-argument-wrapper {
@@ -305,9 +342,8 @@ pre.argparse-usage {
 }
 
 /*
- * Headerlink anchor (¶) - hidden until hover
- * Positioned outside the dt element to the right.
- * Follows Sphinx documentation convention for linkable headings.
+ * Headerlink anchor (¶) — hidden until hover, positioned outside the dt to
+ * the right. Follows Sphinx's documented convention for linkable headings.
  */
 .argparse-argument-name .headerlink {
 	visibility: hidden;
@@ -319,9 +355,7 @@ pre.argparse-usage {
 	text-decoration: none;
 }
 
-/*
- * Show headerlink on hover or when targeted via URL fragment
- */
+/* Show headerlink on hover or when targeted via URL fragment */
 .argparse-argument-wrapper:hover .headerlink,
 .argparse-argument-wrapper:target .headerlink {
 	visibility: visible;
@@ -332,29 +366,7 @@ pre.argparse-usage {
 }
 
 /*
- * Light mode headerlink color overrides
- * Needed because code block has dark background regardless of theme
- */
-body[data-theme="light"] .argparse-argument-name .headerlink {
-	color: #9ca0a5;
-
-	&:hover:not(:visited) {
-		color: #cfd0d0;
-	}
-}
-
-@media (prefers-color-scheme: light) {
-	body:not([data-theme="dark"]) .argparse-argument-name .headerlink {
-		color: #9ca0a5;
-
-		&:hover:not(:visited) {
-			color: #cfd0d0;
-		}
-	}
-}
-
-/*
- * Highlight when targeted via URL fragment
+ * Highlight when targeted via URL fragment.
  * Uses Furo's highlight-on-target color for consistency.
  */
 .argparse-argument-wrapper:target .argparse-argument-name {
@@ -362,10 +374,9 @@ body[data-theme="light"] .argparse-argument-name .headerlink {
 }
 
 /*
- * Argument metadata definition list
- *
- * Renders metadata (Default, Type, Choices, Required) as a horizontal
- * flexbox of key-value pairs and standalone tags.
+ * Argument metadata definition list — renders metadata
+ * (Default, Type, Choices, Required) as a horizontal flexbox of key-value
+ * pairs and standalone tags.
  */
 .argparse-argument-meta {
 	margin: 0.5rem 0 0 0;
@@ -392,22 +403,21 @@ body[data-theme="light"] .argparse-argument-name .headerlink {
 }
 
 .argparse-meta-value .nv {
-	background: var(--argparse-code-background);
+	background: var(--gp-sphinx-argparse-code-bg);
 	border-radius: 0.2rem;
 	padding: 0.1rem 0.3rem;
 	font-family: var(--font-stack--monospace);
 	font-size: var(--code-font-size);
-	color: #e5c07b;
+	color: var(--gp-sphinx-argparse-metavar);
 }
 
 /*
- * Meta tag (e.g., "Required") - follows Furo's guilabel pattern
- * Uses semi-transparent amber background with border for visibility
- * without the harshness of solid fills. Amber conveys "needs attention".
+ * Meta tag (e.g., "Required") — follows Furo's guilabel pattern.
+ * Semi-transparent amber conveys "needs attention" without harshness.
  */
 .argparse-meta-tag {
-	background-color: #fef3c780;
-	border: 1px solid #fcd34d80;
+	background-color: var(--gp-sphinx-argparse-meta-tag-bg);
+	border: 1px solid var(--gp-sphinx-argparse-meta-tag-border);
 	color: var(--color-foreground-primary);
 	font-size: var(--code-font-size);
 	padding: 0.1rem 0.4rem;
@@ -415,22 +425,9 @@ body[data-theme="light"] .argparse-argument-name .headerlink {
 	font-weight: 500;
 }
 
-/* Dark mode: darker amber with adjusted border */
-body[data-theme="dark"] .argparse-meta-tag {
-	background-color: #78350f60;
-	border-color: #b4530980;
-}
-
-@media (prefers-color-scheme: dark) {
-	body:not([data-theme="light"]) .argparse-meta-tag {
-		background-color: #78350f60;
-		border-color: #b4530980;
-	}
-}
-
 /*
- * Help text description
- * Adds spacing above for visual separation from argument name.
+ * Help text description — adds spacing above for visual separation from
+ * the argument name.
  */
 .argparse-argument-help {
 	padding-block-start: 0.5rem;

--- a/packages/sphinx-gp-theme/src/sphinx_gp_theme/theme/theme.conf
+++ b/packages/sphinx-gp-theme/src/sphinx_gp_theme/theme/theme.conf
@@ -1,7 +1,7 @@
 [theme]
 inherit = furo
 stylesheet = styles/furo.css, css/custom.css, css/argparse-highlight.css
-pygments_style = a11y-light
+pygments_style = gp-sphinx-light
 sidebars =
   sidebar/scroll-start.html,
   sidebar/brand.html,

--- a/tests/__snapshots__/test_pygments_style.ambr
+++ b/tests/__snapshots__/test_pygments_style.ambr
@@ -1,0 +1,89 @@
+# serializer version: 1
+# name: test_gp_sphinx_light_html_style_defs
+  '''
+  pre { line-height: 125%; }
+  td.linenos .normal { color: #64748b; background-color: #f1f5f9; padding-left: 5px; padding-right: 5px; }
+  span.linenos { color: #64748b; background-color: #f1f5f9; padding-left: 5px; padding-right: 5px; }
+  td.linenos .special { color: #0f172a; background-color: #dbeafe; padding-left: 5px; padding-right: 5px; }
+  span.linenos.special { color: #0f172a; background-color: #dbeafe; padding-left: 5px; padding-right: 5px; }
+  .highlight .hll { background-color: #dbeafe }
+  .highlight { background: #f8fafc; color: #0F172A }
+  .highlight .c { color: #64748B; font-style: italic } /* Comment */
+  .highlight .err { color: #DC2626; border: 1px solid #DC2626 } /* Error */
+  .highlight .g { color: #0F172A } /* Generic */
+  .highlight .k { color: #7C3AED; font-weight: bold } /* Keyword */
+  .highlight .l { color: #0F172A } /* Literal */
+  .highlight .n { color: #0F172A } /* Name */
+  .highlight .o { color: #0F172A } /* Operator */
+  .highlight .x { color: #0F172A } /* Other */
+  .highlight .p { color: #0F172A } /* Punctuation */
+  .highlight .ch { color: #64748B; font-style: italic } /* Comment.Hashbang */
+  .highlight .cm { color: #64748B; font-style: italic } /* Comment.Multiline */
+  .highlight .cp { color: #7C3AED } /* Comment.Preproc */
+  .highlight .cpf { color: #CA8A04 } /* Comment.PreprocFile */
+  .highlight .c1 { color: #64748B; font-style: italic } /* Comment.Single */
+  .highlight .cs { color: #64748B; font-weight: bold; font-style: italic } /* Comment.Special */
+  .highlight .gd { color: #DC2626 } /* Generic.Deleted */
+  .highlight .ge { color: #0F172A; font-style: italic } /* Generic.Emph */
+  .highlight .ges { color: #0F172A; font-weight: bold; font-style: italic } /* Generic.EmphStrong */
+  .highlight .gr { color: #DC2626 } /* Generic.Error */
+  .highlight .gh { color: #0F172A; font-weight: bold } /* Generic.Heading */
+  .highlight .gi { color: #16A34A } /* Generic.Inserted */
+  .highlight .go { color: #475569 } /* Generic.Output */
+  .highlight .gp { color: #475569; font-weight: bold } /* Generic.Prompt */
+  .highlight .gs { color: #0F172A; font-weight: bold } /* Generic.Strong */
+  .highlight .gu { color: #475569; font-weight: bold } /* Generic.Subheading */
+  .highlight .gt { color: #DC2626 } /* Generic.Traceback */
+  .highlight .kc { color: #EA580C; font-weight: bold } /* Keyword.Constant */
+  .highlight .kd { color: #7C3AED; font-weight: bold } /* Keyword.Declaration */
+  .highlight .kn { color: #7C3AED; font-weight: bold } /* Keyword.Namespace */
+  .highlight .kp { color: #7C3AED } /* Keyword.Pseudo */
+  .highlight .kr { color: #7C3AED; font-weight: bold } /* Keyword.Reserved */
+  .highlight .kt { color: #A855F7 } /* Keyword.Type */
+  .highlight .ld { color: #CA8A04 } /* Literal.Date */
+  .highlight .m { color: #3B82F6 } /* Literal.Number */
+  .highlight .s { color: #CA8A04 } /* Literal.String */
+  .highlight .na { color: #A855F7 } /* Name.Attribute */
+  .highlight .nb { color: #EA580C } /* Name.Builtin */
+  .highlight .nc { color: #0F172A; font-weight: bold } /* Name.Class */
+  .highlight .no { color: #EA580C } /* Name.Constant */
+  .highlight .nd { color: #A855F7 } /* Name.Decorator */
+  .highlight .ni { color: #DC2626; font-weight: bold } /* Name.Entity */
+  .highlight .ne { color: #DC2626; font-weight: bold } /* Name.Exception */
+  .highlight .nf { color: #0F172A } /* Name.Function */
+  .highlight .nl { color: #475569 } /* Name.Label */
+  .highlight .nn { color: #0F172A; font-weight: bold } /* Name.Namespace */
+  .highlight .nx { color: #0F172A } /* Name.Other */
+  .highlight .py { color: #0F172A } /* Name.Property */
+  .highlight .nt { color: #DC2626 } /* Name.Tag */
+  .highlight .nv { color: #0F172A } /* Name.Variable */
+  .highlight .ow { color: #7C3AED; font-weight: bold } /* Operator.Word */
+  .highlight .pm { color: #0F172A } /* Punctuation.Marker */
+  .highlight .w { color: #CBD5E1 } /* Text.Whitespace */
+  .highlight .mb { color: #3B82F6 } /* Literal.Number.Bin */
+  .highlight .mf { color: #3B82F6 } /* Literal.Number.Float */
+  .highlight .mh { color: #3B82F6 } /* Literal.Number.Hex */
+  .highlight .mi { color: #3B82F6 } /* Literal.Number.Integer */
+  .highlight .mo { color: #3B82F6 } /* Literal.Number.Oct */
+  .highlight .sa { color: #CA8A04; font-weight: bold } /* Literal.String.Affix */
+  .highlight .sb { color: #CA8A04 } /* Literal.String.Backtick */
+  .highlight .sc { color: #CA8A04 } /* Literal.String.Char */
+  .highlight .dl { color: #CA8A04 } /* Literal.String.Delimiter */
+  .highlight .sd { color: #64748B; font-style: italic } /* Literal.String.Doc */
+  .highlight .s2 { color: #CA8A04 } /* Literal.String.Double */
+  .highlight .se { color: #B45309; font-weight: bold } /* Literal.String.Escape */
+  .highlight .sh { color: #CA8A04 } /* Literal.String.Heredoc */
+  .highlight .si { color: #B45309; font-weight: bold } /* Literal.String.Interpol */
+  .highlight .sx { color: #CA8A04 } /* Literal.String.Other */
+  .highlight .sr { color: #EA580C } /* Literal.String.Regex */
+  .highlight .s1 { color: #CA8A04 } /* Literal.String.Single */
+  .highlight .ss { color: #CA8A04 } /* Literal.String.Symbol */
+  .highlight .bp { color: #EA580C } /* Name.Builtin.Pseudo */
+  .highlight .fm { color: #A855F7 } /* Name.Function.Magic */
+  .highlight .vc { color: #0F172A } /* Name.Variable.Class */
+  .highlight .vg { color: #0F172A } /* Name.Variable.Global */
+  .highlight .vi { color: #0F172A } /* Name.Variable.Instance */
+  .highlight .vm { color: #A855F7 } /* Name.Variable.Magic */
+  .highlight .il { color: #3B82F6 } /* Literal.Number.Integer.Long */
+  '''
+# ---

--- a/tests/test_pygments_style.py
+++ b/tests/test_pygments_style.py
@@ -1,0 +1,215 @@
+"""Tests for the gp-sphinx-light Pygments style and Furo's emitted CSS.
+
+Covers three layers:
+
+1. The custom :class:`GpSphinxLightStyle` is discoverable via
+   :func:`pygments.styles.get_style_by_name` and exposes the expected
+   token-to-color mappings (CodeMirror-derived light palette).
+2. The :class:`pygments.formatters.HtmlFormatter` output for the style is
+   stable (snapshot assertion).
+3. Sphinx builds with ``sphinx-gp-theme`` produce a ``_static/pygments.css``
+   that contains the light palette in the unscoped block AND a
+   ``body[data-theme="dark"]`` block with the paired monokai dark style.
+"""
+
+from __future__ import annotations
+
+import textwrap
+import typing as t
+
+import pytest
+from pygments import formatters, token
+from pygments.styles import get_style_by_name
+
+from tests._sphinx_scenarios import (
+    ScenarioFile,
+    SharedSphinxResult,
+    SphinxScenario,
+    build_shared_sphinx_result,
+    read_output,
+)
+
+# ---------------------------------------------------------------------------
+# Pure unit tests — style class registration & token mapping
+# ---------------------------------------------------------------------------
+
+
+def test_gp_sphinx_light_resolved_by_name() -> None:
+    """The style is resolvable by its registered name."""
+    style = get_style_by_name("gp-sphinx-light")
+    assert style.__name__ == "GpSphinxLightStyle"
+    assert style.background_color == "#f8fafc"
+
+
+def test_gp_sphinx_light_line_number_palette() -> None:
+    """Line-number gutter uses the slate-100 / slate-500 palette."""
+    style = get_style_by_name("gp-sphinx-light")
+    assert style.line_number_color == "#64748b"
+    assert style.line_number_background_color == "#f1f5f9"
+
+
+class TokenColorCase(t.NamedTuple):
+    """Expected color/style snippet for a Pygments token."""
+
+    test_id: str
+    token: token._TokenType
+    expected_substring: str
+
+
+_TOKEN_COLOR_FIXTURES: list[TokenColorCase] = [
+    TokenColorCase(
+        test_id="comment-italic-slate",
+        token=token.Comment,
+        expected_substring="italic #64748b",
+    ),
+    TokenColorCase(
+        test_id="keyword-bold-purple",
+        token=token.Keyword,
+        expected_substring="bold #7c3aed",
+    ),
+    TokenColorCase(
+        test_id="operator-word-bold-purple",
+        token=token.Operator.Word,
+        expected_substring="bold #7c3aed",
+    ),
+    TokenColorCase(
+        test_id="string-yellow",
+        token=token.String,
+        expected_substring="#ca8a04",
+    ),
+    TokenColorCase(
+        test_id="number-blue",
+        token=token.Number,
+        expected_substring="#3b82f6",
+    ),
+    TokenColorCase(
+        test_id="builtin-orange",
+        token=token.Name.Builtin,
+        expected_substring="#ea580c",
+    ),
+    TokenColorCase(
+        test_id="tag-red",
+        token=token.Name.Tag,
+        expected_substring="#dc2626",
+    ),
+    TokenColorCase(
+        test_id="attribute-purple-light",
+        token=token.Name.Attribute,
+        expected_substring="#a855f7",
+    ),
+    TokenColorCase(
+        test_id="generic-inserted-green",
+        token=token.Generic.Inserted,
+        expected_substring="#16a34a",
+    ),
+    TokenColorCase(
+        test_id="generic-deleted-red",
+        token=token.Generic.Deleted,
+        expected_substring="#dc2626",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    list(TokenColorCase._fields),
+    _TOKEN_COLOR_FIXTURES,
+    ids=[case.test_id for case in _TOKEN_COLOR_FIXTURES],
+)
+def test_gp_sphinx_light_token_palette(
+    test_id: str,
+    token: token._TokenType,
+    expected_substring: str,
+) -> None:
+    """Each documented token maps to the expected CodeMirror-derived value."""
+    style = get_style_by_name("gp-sphinx-light")
+    assert expected_substring in style.styles[token], (
+        f"{test_id}: {token} -> {style.styles[token]!r} missing {expected_substring!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Snapshot — HtmlFormatter style defs
+# ---------------------------------------------------------------------------
+
+
+def test_gp_sphinx_light_html_style_defs(
+    snapshot_html_fragment: t.Callable[..., None],
+) -> None:
+    """The HtmlFormatter CSS for the style is stable across runs.
+
+    Locks the full per-token CSS surface so accidental drift in any color or
+    weight surfaces in CI rather than only at visual review time.
+    """
+    formatter = formatters.HtmlFormatter(style="gp-sphinx-light")
+    css: str = formatter.get_style_defs(".highlight")  # type: ignore[no-untyped-call]
+    snapshot_html_fragment(css)
+
+
+# ---------------------------------------------------------------------------
+# Sphinx integration — light + dark scopes in built pygments.css
+# ---------------------------------------------------------------------------
+
+
+_INTEGRATION_CONF_PY = textwrap.dedent(
+    """\
+    project = "gp-sphinx-pygments-test"
+    extensions = ["myst_parser"]
+    html_theme = "sphinx-gp-theme"
+    pygments_style = "gp-sphinx-light"
+    pygments_dark_style = "monokai"
+    master_doc = "index"
+    source_suffix = {".md": "markdown"}
+    exclude_patterns = []
+    """
+)
+
+_INTEGRATION_INDEX_MD = textwrap.dedent(
+    """\
+    # Pygments smoke test
+
+    ```python
+    def greet(name: str) -> str:
+        return f"hello {name}"
+    ```
+    """
+)
+
+
+@pytest.fixture(scope="module")
+def gp_sphinx_pygments_result(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> SharedSphinxResult:
+    """Build a tiny Sphinx project using sphinx-gp-theme + paired styles."""
+    cache_root = tmp_path_factory.mktemp("gp-sphinx-pygments")
+    scenario = SphinxScenario(
+        files=(
+            ScenarioFile("conf.py", _INTEGRATION_CONF_PY),
+            ScenarioFile("index.md", _INTEGRATION_INDEX_MD),
+        ),
+    )
+    return build_shared_sphinx_result(cache_root, scenario)
+
+
+@pytest.mark.integration
+def test_built_pygments_css_contains_light_palette(
+    gp_sphinx_pygments_result: SharedSphinxResult,
+) -> None:
+    """The unscoped ``.highlight`` block carries the CodeMirror light palette."""
+    css = read_output(gp_sphinx_pygments_result, "_static/pygments.css").lower()
+    assert ".highlight .k {" in css
+    assert "#7c3aed" in css
+    assert "#ca8a04" in css
+    assert "#3b82f6" in css
+    assert "background: #f8fafc" in css
+
+
+@pytest.mark.integration
+def test_built_pygments_css_contains_dark_scope(
+    gp_sphinx_pygments_result: SharedSphinxResult,
+) -> None:
+    """Furo emits a ``body[data-theme="dark"]`` block for the paired dark style."""
+    css = read_output(gp_sphinx_pygments_result, "_static/pygments.css").lower()
+    assert 'body[data-theme="dark"] .highlight' in css
+    # Monokai-specific colours that should appear only inside the dark scope.
+    assert "#272822" in css  # monokai background
+    assert "#66d9ef" in css  # monokai keyword cyan


### PR DESCRIPTION
## Summary

- Add a new **`gp-sphinx-light`** Pygments style (CodeMirror palette: slate-50 bg, purple keywords, yellow strings, blue numbers, slate-500 italic comments) and register it via the `pygments.styles` entry point in `sphinx-gp-theme`.
- Default the workspace theme to **`gp-sphinx-light` (light) + `monokai` (dark)** so Furo's `body[data-theme]`-scoped pygments overlay actually renders light code blocks in light mode instead of monokai-on-light.
- Refactor `argparse-highlight.css` to drive every token color through `--gp-sphinx-argparse-*` custom properties, with CodeMirror-light defaults at `:root` and One Dark overrides under `body[data-theme="dark"]` and the `prefers-color-scheme: dark` fallback. Drops ~50 hardcoded hex literals and the now-obsolete light-mode headerlink workaround. `--argparse-code-background` is kept as a back-compat alias.
- Lock the new pairing into CI with three test layers in `tests/test_pygments_style.py`: pure-unit token-palette assertions, a syrupy snapshot of `HtmlFormatter.get_style_defs(".highlight")`, and a `@pytest.mark.integration` build that asserts both the unscoped light palette *and* the `body[data-theme="dark"]` monokai scope are present in the built `pygments.css`. Suite: 1216 → 1231 passed.

## Test plan

- [ ] `uv run ruff format .`
- [ ] `uv run ruff check .`
- [ ] `uv run mypy src tests`
- [ ] `uv run pytest`
- [ ] `uv run pytest tests/test_pygments_style.py -v` (new coverage)
- [ ] `just build-docs` and visually confirm in a browser:
  - [ ] Light mode: code blocks render on slate-50 background with purple keywords / yellow strings
  - [ ] Dark mode: code blocks render with monokai (cyan keywords on `#272822`)
  - [ ] argparse directives: option/metavar/command tokens recolor correctly when toggling the theme