### PR TITLE
Auto-build vite assets in docs/ justfile

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,6 +52,27 @@ jobs:
         if: steps.changes.outputs.publishable == 'true'
         uses: extractions/setup-just@v4
 
+      - name: Set up pnpm
+        if: steps.changes.outputs.publishable == 'true'
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10
+
+      - name: Set up Node
+        if: steps.changes.outputs.publishable == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install JS workspace
+        if: steps.changes.outputs.publishable == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Build vite-managed theme assets
+        if: steps.changes.outputs.publishable == 'true'
+        run: pnpm --filter @gp-sphinx/furo-theme-web exec vite build
+
       - name: Print Python versions
         if: steps.changes.outputs.publishable == 'true'
         run: |

--- a/CHANGES
+++ b/CHANGES
@@ -39,7 +39,9 @@ its own. (#25)
 
 Transparent Vite + pnpm orchestration for theme asset compilation.
 No-op in production builds; activates under `sphinx-autobuild` to
-provide live CSS/JS rebuilds during authoring. (#25)
+provide live CSS/JS rebuilds during authoring. The package page
+also documents justfile and Makefile recipes for wiring `just build`
+/ `make build` to run vite before plain `sphinx-build`. (#25, #26)
 
 ## gp-sphinx 0.0.1a14 (2026-05-02)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,6 +4,29 @@ from __future__ import annotations
 
 import pathlib
 import sys
+import typing as t
+
+from pygments.lexer import RegexLexer, bygroups as _bygroups, include
+from pygments.token import (
+    Comment,
+    Keyword,
+    Name,
+    Number,
+    Operator,
+    Punctuation,
+    String,
+    Text,
+)
+from sphinx.highlighting import lexers
+
+# ``pygments.lexer.bygroups`` ships untyped, which trips
+# ``[no-untyped-call]`` under our strict mypy config when the
+# function is invoked inside a typed module like this conf.py.
+# Aliasing through a ``t.Callable[..., t.Any]`` re-binding keeps the
+# call sites readable and satisfies mypy without disabling the rule
+# globally. Pattern taken from
+# ``~/work/cihai/unihan-etl/docs/conf.py``.
+bygroups: t.Callable[..., t.Any] = _bygroups
 
 # Bootstrap: allow importing workspace packages during development
 cwd = pathlib.Path(__file__).parent
@@ -81,3 +104,117 @@ conf = merge_sphinx_config(
     vite_orchestration=True,
 )
 globals().update(conf)
+
+
+class JustfileLexer(RegexLexer):
+    """Pygments lexer for ``justfile`` (https://just.systems/) syntax.
+
+    Pygments has no built-in justfile lexer at the time of writing,
+    so docs that show justfile snippets either fall back to plain
+    ``text`` (no highlighting) or pick a near-relative like ``make``
+    that mistokenises just-specific syntax (``[private]`` recipe
+    attributes, ``{{ … }}`` interpolations, ``set`` / ``import``
+    keywords). This lexer covers the syntax we actually use in
+    gp-sphinx docs:
+
+    - ``# ...`` comments
+    - ``[private]`` / ``[no-exit-message]`` / etc. recipe attributes
+    - ``set shell := [...]`` / ``import "path"`` / ``mod name`` /
+      ``alias x := y`` top-level statements
+    - ``var := "value"`` variable assignments
+    - ``recipe-name dep1 dep2: prereq`` recipe headers
+    - ``{{ expression }}`` interpolations
+    - String literals (``"..."``, ``'...'``, ```backticks```)
+
+    Recipe bodies are not parsed deeply — they're treated as Text
+    until the next non-indented line. Most justfiles delegate the
+    body to a shell, and accurate sub-shell highlighting is more
+    work than the docs need.
+
+    Pattern follows the ``CsvLexer`` / ``TsvLexer`` shape in
+    ~/work/cihai/unihan-etl/docs/conf.py.
+    """
+
+    name = "Justfile"
+    aliases: t.ClassVar[list[str]] = ["just", "justfile"]
+    filenames: t.ClassVar[list[str]] = ["justfile", "Justfile", "*.just"]
+    mimetypes: t.ClassVar[list[str]] = ["text/x-justfile"]
+
+    tokens: t.ClassVar = {
+        "root": [
+            (r"#.*$", Comment.Single),
+            (r"\s+", Text),
+            # Recipe attributes: [private], [no-exit-message], [confirm], etc.
+            (
+                r"^(\[)([a-zA-Z_-]+)((?:\s*\([^)]*\))?)(\])",
+                bygroups(
+                    Punctuation,
+                    Name.Decorator,
+                    Text,
+                    Punctuation,
+                ),
+            ),
+            # Settings: set shell := [...]
+            (
+                r"^(set)(\s+)([a-zA-Z_-]+)",
+                bygroups(Keyword.Reserved, Text, Name.Variable),
+                "assignment",
+            ),
+            # Module / alias / export / import / unexport at line start.
+            (
+                r"^(import|mod|alias|export|unexport)\b",
+                Keyword.Reserved,
+            ),
+            # Variable assignment at line start.
+            (
+                r"^([a-zA-Z_][a-zA-Z0-9_-]*)(\s*)(:=)",
+                bygroups(Name.Variable, Text, Operator),
+                "assignment",
+            ),
+            # Recipe header: name [params]: [prereqs]
+            (
+                r"^([a-zA-Z_][a-zA-Z0-9_-]*)((?:\s+[a-zA-Z0-9_+*=\"'-]+)*)(\s*:)",
+                bygroups(Name.Function, Text, Punctuation),
+                "recipe-body",
+            ),
+            include("strings"),
+        ],
+        "assignment": [
+            (r"\n", Text, "#pop"),
+            include("strings"),
+            (r"\{\{", String.Interpol, "interpol"),
+            (r"[+\-*/%]", Operator),
+            (r"[a-zA-Z_][a-zA-Z0-9_-]*", Name),
+            (r"[0-9]+", Number),
+            (r"[\[\](),]", Punctuation),
+            (r"\s+", Text),
+            (r":=", Operator),
+            (r".", Text),
+        ],
+        "recipe-body": [
+            # End of body: a line that doesn't start with whitespace.
+            (r"\n(?=\S)", Text, "#pop"),
+            (r"\n", Text),
+            (r"#.*$", Comment.Single),
+            (r"\{\{", String.Interpol, "interpol"),
+            include("strings"),
+            (r".", Text),
+        ],
+        "interpol": [
+            (r"\}\}", String.Interpol, "#pop"),
+            (r"[a-zA-Z_][a-zA-Z0-9_]*", Name.Variable),
+            (r"\(", Punctuation),
+            (r"\)", Punctuation),
+            include("strings"),
+            (r"\s+", Text),
+            (r".", Text),
+        ],
+        "strings": [
+            (r'"[^"\n]*"', String.Double),
+            (r"'[^'\n]*'", String.Single),
+            (r"`[^`\n]*`", String.Backtick),
+        ],
+    }
+
+
+lexers["just"] = JustfileLexer()

--- a/docs/justfile
+++ b/docs/justfile
@@ -20,26 +20,66 @@ allsphinxopts := "-d " + builddir + "/doctrees " + sphinxopts + " ."
 default:
     @just --list
 
+# Build vite-managed theme assets (CSS + JS) before any HTML-output
+# build. Prerequisite of every HTML-output builder below.
+#
+# Resolution chain:
+#   1. ``gp_furo_theme.get_vite_root()`` returns the absolute path of
+#      ``packages/gp-furo-theme/web/`` under a workspace checkout, or
+#      ``None`` when running from an installed wheel (the wheel ships
+#      pre-built assets — no vite step needed).
+#   2. If ``node_modules/`` is absent, a one-shot
+#      ``pnpm install --frozen-lockfile`` populates it. Mirrors
+#      ``gp_sphinx_vite.hooks._ensure_node_modules`` semantics so
+#      ``just clean; just html`` works without a separate install.
+#   3. ``pnpm exec vite build`` produces
+#      ``static/{scripts/furo.js,styles/furo-tw.css}`` in the theme
+#      tree, where sphinx-build later copies them into ``_static/``.
+#
+# Skip cleanly when gp-furo-theme is installed from a wheel, or when
+# the user genuinely lacks pnpm — the build proceeds without fresh
+# assets and any cached output remains in place. Non-HTML builders
+# (man, latex, gettext, etc.) don't depend on this recipe at all.
+[private]
+_assets-build:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    web_root=$(uv run python -c 'import gp_furo_theme; r = gp_furo_theme.get_vite_root(); print(r or "")' 2>/dev/null || true)
+    if [ -z "$web_root" ]; then
+        echo "[assets] gp_furo_theme.get_vite_root() returned None — assuming wheel install (pre-built assets in tree)"
+        exit 0
+    fi
+    if ! command -v pnpm >/dev/null 2>&1; then
+        echo "[assets] pnpm not on PATH; skipping vite build (any pre-existing output remains)"
+        exit 0
+    fi
+    if [ ! -d "$web_root/node_modules" ]; then
+        echo "[assets] node_modules missing in $web_root — running pnpm install --frozen-lockfile"
+        (cd "$web_root" && pnpm install --frozen-lockfile)
+    fi
+    echo "[assets] running pnpm exec vite build in $web_root"
+    (cd "$web_root" && pnpm exec vite build)
+
 # Build HTML documentation
-html:
+html: _assets-build
     {{ sphinxbuild }} -b dirhtml {{ allsphinxopts }} {{ builddir }}/html
     @echo ""
     @echo "Build finished. The HTML pages are in {{ builddir }}/html."
 
 # Build directory HTML files
-dirhtml:
+dirhtml: _assets-build
     {{ sphinxbuild }} -b dirhtml {{ allsphinxopts }} {{ builddir }}/dirhtml
     @echo ""
     @echo "Build finished. The HTML pages are in {{ builddir }}/dirhtml."
 
 # Build single HTML file
-singlehtml:
+singlehtml: _assets-build
     {{ sphinxbuild }} -b singlehtml {{ allsphinxopts }} {{ builddir }}/singlehtml
     @echo ""
     @echo "Build finished. The HTML page is in {{ builddir }}/singlehtml."
 
 # Build EPUB
-epub:
+epub: _assets-build
     {{ sphinxbuild }} -b epub {{ allsphinxopts }} {{ builddir }}/epub
     @echo ""
     @echo "Build finished. The epub file is in {{ builddir }}/epub."
@@ -75,25 +115,26 @@ json:
     @echo ""
     @echo "Build finished; now you can process the JSON files."
 
-# Clean build directory
+# Clean build directory and the vite-built theme assets
 [confirm]
 clean:
     rm -rf {{ builddir }}/*
+    rm -rf ../packages/gp-furo-theme/src/gp_furo_theme/theme/gp-furo/static/
 
 # Build HTML help files
-htmlhelp:
+htmlhelp: _assets-build
     {{ sphinxbuild }} -b htmlhelp {{ allsphinxopts }} {{ builddir }}/htmlhelp
     @echo ""
     @echo "Build finished; now you can run HTML Help Workshop with the .hhp project file in {{ builddir }}/htmlhelp."
 
 # Build Qt help files
-qthelp:
+qthelp: _assets-build
     {{ sphinxbuild }} -b qthelp {{ allsphinxopts }} {{ builddir }}/qthelp
     @echo ""
     @echo "Build finished; now you can run 'qcollectiongenerator' with the .qhcp project file in {{ builddir }}/qthelp."
 
 # Build Devhelp files
-devhelp:
+devhelp: _assets-build
     {{ sphinxbuild }} -b devhelp {{ allsphinxopts }} {{ builddir }}/devhelp
     @echo ""
     @echo "Build finished."

--- a/docs/packages/gp-sphinx-vite.md
+++ b/docs/packages/gp-sphinx-vite.md
@@ -59,7 +59,7 @@ degradation; any pre-existing output remains in place).
 
 ### justfile
 
-```just
+```text
 # Build vite-managed theme assets before any HTML-output build.
 [private]
 _assets-build:

--- a/docs/packages/gp-sphinx-vite.md
+++ b/docs/packages/gp-sphinx-vite.md
@@ -39,6 +39,110 @@ gp_sphinx_vite_root = None
 ```{package-reference} gp-sphinx-vite
 ```
 
+## Wiring `just build` / `make build` for downstream users
+
+[sphinx-autobuild] runs `gp_sphinx_vite`'s `builder-inited` hook,
+which detects the autobuild process by argv0 / the `SPHINX_AUTOBUILD`
+env var and spawns `pnpm exec vite build --watch` itself — so
+`sphinx-autobuild docs/ _build/html` "just works" with no extra
+plumbing. Plain `sphinx-build` runs in `prod` mode where the
+extension is intentionally a no-op (so wheels published to PyPI
+never require a Node runtime), so the `vite build` step has to
+happen *before* `sphinx-build` in the orchestration layer that
+calls it.
+
+A small `assets-build` recipe that depends on every HTML-output
+target covers the gap. The recipe is idempotent — it skips the
+build when no `web/` source tree is present (wheel install with
+pre-built assets) or when `pnpm` isn't on PATH (graceful
+degradation; any pre-existing output remains in place).
+
+### justfile
+
+```just
+# Build vite-managed theme assets before any HTML-output build.
+[private]
+_assets-build:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    web_root=$(uv run python -c 'import gp_furo_theme; r = gp_furo_theme.get_vite_root(); print(r or "")' 2>/dev/null || true)
+    if [ -z "$web_root" ]; then
+        echo "[assets] no web/ source tree (wheel install) — skipping vite build"
+        exit 0
+    fi
+    if ! command -v pnpm >/dev/null 2>&1; then
+        echo "[assets] pnpm not on PATH; skipping vite build"
+        exit 0
+    fi
+    if [ ! -d "$web_root/node_modules" ]; then
+        (cd "$web_root" && pnpm install --frozen-lockfile)
+    fi
+    (cd "$web_root" && pnpm exec vite build)
+
+html: _assets-build
+    sphinx-build -b dirhtml . _build/html
+
+dirhtml: _assets-build
+    sphinx-build -b dirhtml . _build/dirhtml
+```
+
+The `[private]` attribute hides `_assets-build` from
+`just --list`; it's a pure dependency target. Add the same
+prerequisite to every other HTML-output builder you ship
+(`singlehtml`, `htmlhelp`, `qthelp`, `devhelp`, `epub`).
+Non-HTML builders (`text`, `man`, `latex`, `gettext`,
+`linkcheck`, `doctest`) don't need the theme assets and should
+*not* depend on `_assets-build`.
+
+### Makefile
+
+```makefile
+.PHONY: _assets-build html dirhtml clean
+
+_assets-build:
+	@web_root=$$(uv run python -c 'import gp_furo_theme; r = gp_furo_theme.get_vite_root(); print(r or "")' 2>/dev/null || true); \
+	if [ -z "$$web_root" ]; then \
+		echo "[assets] no web/ source tree (wheel install) — skipping vite build"; \
+		exit 0; \
+	fi; \
+	if ! command -v pnpm >/dev/null 2>&1; then \
+		echo "[assets] pnpm not on PATH; skipping vite build"; \
+		exit 0; \
+	fi; \
+	if [ ! -d "$$web_root/node_modules" ]; then \
+		(cd "$$web_root" && pnpm install --frozen-lockfile); \
+	fi; \
+	(cd "$$web_root" && pnpm exec vite build)
+
+html: _assets-build
+	sphinx-build -b dirhtml . _build/html
+
+dirhtml: _assets-build
+	sphinx-build -b dirhtml . _build/dirhtml
+```
+
+### Locating the vite root from your own theme
+
+The recipe shells into `gp_furo_theme.get_vite_root()` because that
+is the canonical helper for the gp-sphinx-shipped theme. If you
+maintain a *different* Sphinx theme parent that ships its own
+Vite-managed assets, expose an equivalent helper from your
+package's `__init__.py`:
+
+```python
+import pathlib
+
+def get_vite_root() -> pathlib.Path | None:
+    """Return the absolute web/ path under a workspace checkout, or None for wheel installs."""
+    candidate = pathlib.Path(__file__).resolve().parents[2] / "web"
+    return candidate if candidate.is_dir() else None
+```
+
+Then swap the `gp_furo_theme` import in the recipe for your own
+package name. This keeps the orchestration layer agnostic about
+where the source tree actually lives — wheel installs stay
+zero-Node, workspace checkouts get a fresh build automatically.
+
 ## Reference
 
 ```{eval-rst}

--- a/docs/packages/gp-sphinx-vite.md
+++ b/docs/packages/gp-sphinx-vite.md
@@ -59,7 +59,7 @@ degradation; any pre-existing output remains in place).
 
 ### justfile
 
-```text
+```just
 # Build vite-managed theme assets before any HTML-output build.
 [private]
 _assets-build:


### PR DESCRIPTION
## Summary

- **Add** `_assets-build` private recipe in `docs/justfile` that runs `pnpm exec vite build` before any HTML-output sphinx build, with auto-install of `node_modules/` if missing.
- **Wire** every HTML-output builder (`html`, `dirhtml`, `singlehtml`, `epub`, `htmlhelp`, `qthelp`, `devhelp`) as a dependent of `_assets-build`. Non-HTML builders skip the dependency.
- **Document** the same pattern (justfile + Makefile snippets, plus an explanation of the sphinx-autobuild-vs-sphinx-build divergence) on `docs/packages/gp-sphinx-vite.md` for downstream users wiring up their own docs orchestration.

Closes the gap that took down https://gp-sphinx.git-pull.com/ during the v0.0.1a15 attempt: cold checkouts and `just clean` runs left `furo-tw.css` / `furo.js` absent from the theme's static directory, sphinx-build silently skipped the missing static files (no `-W` warning), and the deployed HTML referenced 403'd assets.

## Why orchestration-layer, not extension-layer

`sphinx-autobuild` runs `gp-sphinx-vite`'s `builder-inited` hook, which detects the autobuild via argv0 / `SPHINX_AUTOBUILD` env and spawns `pnpm exec vite build --watch` itself — so `just start` already Just Works (per commit `013884d`'s auto-pnpm-install). Plain `sphinx-build` runs in `prod` mode where the extension is intentionally a no-op (production wheel installs must not require a Node runtime). So the only correct place to plug the gap for `just build` is the orchestration layer that calls `sphinx-build`.

## Changes

### `docs/justfile`

Adds:

```just
[private]
_assets-build:
    #!/usr/bin/env bash
    set -euo pipefail
    web_root=$(uv run python -c 'import gp_furo_theme; r = gp_furo_theme.get_vite_root(); print(r or "")' 2>/dev/null || true)
    if [ -z "$web_root" ]; then
        echo "[assets] gp_furo_theme.get_vite_root() returned None — assuming wheel install"
        exit 0
    fi
    if ! command -v pnpm >/dev/null 2>&1; then
        echo "[assets] pnpm not on PATH; skipping vite build"
        exit 0
    fi
    if [ ! -d "$web_root/node_modules" ]; then
        (cd "$web_root" && pnpm install --frozen-lockfile)
    fi
    (cd "$web_root" && pnpm exec vite build)
```

Each HTML-output recipe gains the `: _assets-build` prerequisite. `clean` is extended to wipe the vite output directory so the next build is genuinely cold.

### `docs/packages/gp-sphinx-vite.md`

New `## Wiring just build / make build for downstream users` section with the canonical recipe in both justfile and Makefile shapes, plus a pointer to `gp_furo_theme.get_vite_root()` for users on alternate theme parents.

## Design decisions

**Resolve the vite root via `gp_furo_theme.get_vite_root()`, not hard-coded path.** The helper returns `None` for wheel installs (no `web/` source tree exists, pre-built assets are already in the wheel) and the absolute path for workspace checkouts. The recipe degrades gracefully in both cases.

**Skip silently when pnpm isn't on PATH.** Some users may not have pnpm installed (e.g. installing gp-sphinx-vite from a wheel and never planning to author theme assets). The recipe skips with a one-line note rather than aborting the parent build — any pre-existing output remains in place.

**Mirror `gp_sphinx_vite.hooks._ensure_node_modules` semantics in shell.** Auto-install of `node_modules/` on first run — same code path the autobuild flow already takes — so `just clean; just html` works without a separate `pnpm install` step.

## Verification

Cold start works end-to-end:

```console
$ rm -rf packages/gp-furo-theme/src/gp_furo_theme/theme/gp-furo/static/
$ just build-docs
[assets] running pnpm exec vite build in .../web
... 57.94 kB furo-tw.css, 4.51 kB furo.js
... build succeeded.

$ ls docs/_build/html/_static/styles/furo-tw.css docs/_build/html/_static/scripts/furo.js
   both present
```

## Test plan

- [x] `uv run ruff check . --fix --show-fixes` — clean
- [x] `uv run ruff format .` — unchanged
- [x] `uv run mypy` — clean (197 source files)
- [x] `uv run py.test --reruns 0 -vvv` — 1317 passed, 159 skipped
- [x] `just build-docs` from a wiped static dir — produces styled output with both `furo-tw.css` and `furo.js` in `_build/html/_static/`
- [x] Manual verification that downstream-facing snippets in `docs/packages/gp-sphinx-vite.md` render correctly under `just build-docs`

## Out of scope (follow-up)

The `.github/workflows/{docs,tests,release}.yml` workflows still call `uv run sphinx-build` / `uv build` / smoke runners directly without any pnpm/vite step — same root cause as the live-site outage, but on the CI side. Will land as a separate commit on this PR (and the PR's [DO NOT MERGE] branch trigger lets us validate the deploy actually styles correctly before merging to main).

The `gp-furo-theme` smoke runner in `scripts/ci/package_tools.py` is also separately broken (registers `gp_furo_theme` as an extension instead of via `html_theme = "gp-furo"`, tripping the package's non-HTML-builder guard) — not in this PR's scope.