### PR TITLE
feat(gp-sphinx[fonts]): default preload covers heading/italic/bold-code FOUT

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,17 @@ $ uv add gp-sphinx --prerelease allow
 
 <!-- To maintainers and contributors: Please add notes for the forthcoming version below -->
 
+### What's new
+
+#### `gp-sphinx`: Default font-preload list now covers heading, italic, and bold-code FOUT
+
+`DEFAULT_SPHINX_FONT_PRELOAD` adds IBM Plex Sans 500 / 600 normal
+(`h1`–`h6` and `blockquote.epigraph`), Sans 400 italic (`<em>` body
+text and announcement bars), and Mono 700 normal (bold inline code).
+Downstream consumers that render those surfaces no longer need a
+local `sphinx_font_preload` override to avoid first-paint FOUT.
+(#34)
+
 ### Bug fixes
 
 #### `gp-sphinx`: MystLexer highlights `:::{directive}` colon-fences

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -130,7 +130,7 @@ These are injected even though they are not exposed as `DEFAULT_*` constants:
 | Constant | Value |
 | --- | --- |
 | `DEFAULT_SPHINX_FONTS` | IBM Plex Sans (400/500/600/700, normal+italic) and IBM Plex Mono (400, normal+italic) Fontsource definitions |
-| `DEFAULT_SPHINX_FONT_PRELOAD` | `("IBM Plex Sans", 400, "normal")`, `("IBM Plex Sans", 700, "normal")`, `("IBM Plex Mono", 400, "normal")` |
+| `DEFAULT_SPHINX_FONT_PRELOAD` | IBM Plex Sans 400 / 500 / 600 / 700 normal + 400 italic, IBM Plex Mono 400 / 700 normal |
 | `DEFAULT_SPHINX_FONT_FALLBACKS` | Metric-adjusted Arial and Courier fallback declarations |
 | `DEFAULT_SPHINX_FONT_CSS_VARIABLES` | `--font-stack`, `--font-stack--monospace`, `--font-stack--headings` |
 

--- a/packages/gp-sphinx/src/gp_sphinx/defaults.py
+++ b/packages/gp-sphinx/src/gp_sphinx/defaults.py
@@ -232,15 +232,32 @@ Examples
 
 DEFAULT_SPHINX_FONT_PRELOAD: list[tuple[str, int, str]] = [
     ("IBM Plex Sans", 400, "normal"),
+    ("IBM Plex Sans", 500, "normal"),
+    ("IBM Plex Sans", 600, "normal"),
     ("IBM Plex Sans", 700, "normal"),
+    ("IBM Plex Sans", 400, "italic"),
     ("IBM Plex Mono", 400, "normal"),
+    ("IBM Plex Mono", 700, "normal"),
 ]
 """Font preload hints for critical rendering path.
+
+Each entry is ``(family, weight, style)``. Faces in this list are
+emitted as ``<link rel="preload" as="font">`` tags so the browser
+fetches them in parallel with the critical CSS/HTML, before
+``font-display: block`` would otherwise hide text waiting on a
+lazy ``@font-face`` request.
+
+The list covers every face Furo / ``furo-tw.css`` is observed to
+demand above the fold: body (Sans 400), headings + sidebar labels
+(Sans 500), epigraph blockquotes (Sans 600), strong / current
+sidebar (Sans 700), inline ``<em>`` and announcement-bar emphasis
+(Sans 400 italic), code blocks (Mono 400), and bold inline code
+``<strong><code>`` (Mono 700).
 
 Examples
 --------
 >>> len(DEFAULT_SPHINX_FONT_PRELOAD)
-3
+7
 """
 
 DEFAULT_SPHINX_FONT_FALLBACKS: list[dict[str, str]] = [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -218,7 +218,7 @@ def test_merge_sphinx_config_default_fonts() -> None:
     )
     assert len(result["sphinx_fonts"]) == 2
     assert result["sphinx_fonts"][0]["family"] == "IBM Plex Sans"
-    assert len(result["sphinx_font_preload"]) == 3
+    assert len(result["sphinx_font_preload"]) == 7
     assert len(result["sphinx_font_fallbacks"]) == 2
     assert "--font-stack" in result["sphinx_font_css_variables"]
 


### PR DESCRIPTION
## Summary

- **Expand** `DEFAULT_SPHINX_FONT_PRELOAD` from the existing trio (Sans 400, Sans 700, Mono 400) to cover every face Furo / `furo-tw.css` is observed to demand above the fold.
- **Eliminate** first-paint FOUT on bold headings, italic body text, and bold inline code by default — downstream consumers no longer need to extend the list locally.

## Why these specific faces

| Face added | Surface that needs it |
|---|---|
| Sans 500 normal | `h1`–`h6`, sidebar labels |
| Sans 600 normal | `blockquote.epigraph` |
| Sans 400 italic | `<em>` body text, announcement-bar emphasis |
| Mono 700 normal | bold inline code (`<strong><code>`, MyST `**\`code\`**`) |

These were discovered while debugging first-paint FOUT on libtmux-mcp ([tmux-python/libtmux-mcp#36](https://github.com/tmux-python/libtmux-mcp/pull/36)). All four are pulled by Furo's own CSS, not project-specific code, so every gp-furo consumer that renders any of these surfaces ships the same FOUT until they extend the preload list themselves. Moving the additions upstream means new sites get correct first-paint behaviour for free.

## Changes

- **`packages/gp-sphinx/src/gp_sphinx/defaults.py`**: Append the four tuples; reorder so faces are grouped by family with weights ascending. Doctest `len(DEFAULT_SPHINX_FONT_PRELOAD)` bumped from `3` to `7`. Docstring expanded to name each face's purpose so the constant explains itself.
- **`tests/test_config.py`**: `test_merge_sphinx_config_default_fonts` length assertion bumped from `3` to `7` (matches the existing brittle-by-count style of nearby asserts).
- **`docs/configuration.md`**: Font defaults table cell for the constant shortened to a one-line summary so it stays readable as the list grows.
- **`CHANGES`**: New `### What's new` entry under `## gp-sphinx 0.0.1 (unreleased)` describing the FOUT impact.

## What is NOT in scope

- Adding more faces (Sans 300, Mono 500/600, more italics). The constant is intentionally minimal — every preload byte contends with critical CSS/HTML on the network. Only faces with documented above-the-fold use go in.
- Promoting the constant from `gp-sphinx` defaults into `sphinx-fonts` itself. The current ownership (gp-sphinx ships the IBM-Plex-flavoured defaults; sphinx-fonts is theme-agnostic and registers the config option) is correct.
- Editing libtmux-mcp's local override. That cleanup happens in libtmux-mcp once a gp-sphinx release ships these defaults.

## Test plan

- [x] `uv run ruff format .` — formatting unchanged
- [x] `uv run ruff check . --fix --show-fixes` — lint clean
- [x] `uv run mypy` — types clean across 221 source files
- [x] `uv run pytest --doctest-modules packages/gp-sphinx/src/gp_sphinx/defaults.py` — doctest passes with new length
- [x] `uv run pytest tests/test_config.py::test_merge_sphinx_config_default_fonts` — assertion passes with `== 7`
- [x] `uv run pytest` — full suite green (1473 passed, 161 skipped)
