### PR TITLE
sphinx-vite-builder: fix CSS/JS live-reload under sphinx-autobuild

### DIFF
--- a/docs/justfile
+++ b/docs/justfile
@@ -185,8 +185,25 @@ dev:
 
 # Start sphinx-autobuild server
 start:
-    uv run sphinx-autobuild -b dirhtml "{{ sourcedir }}" "{{ builddir }}" {{ sphinxopts }} --port {{ http_port }}
+    uv run sphinx-autobuild -b dirhtml "{{ sourcedir }}" "{{ builddir }}" {{ sphinxopts }} \
+        --port {{ http_port }} \
+        --watch ../packages \
+        --re-ignore '/node_modules(/|$)' \
+        --re-ignore '/__pycache__(/|$)' \
+        --re-ignore '/\.pytest_cache(/|$)' \
+        --re-ignore '/dist(/|$)' \
+        --re-ignore '/_build(/|$)' \
+        --re-ignore '/packages/[^/]+/src/[^/]+/theme/[^/]+/static(/|$)'
 
 # Design mode: watch static files and disable incremental builds
 design:
-    uv run sphinx-autobuild -b dirhtml "{{ sourcedir }}" "{{ builddir }}" {{ sphinxopts }} --port {{ http_port }} --watch "." -a
+    uv run sphinx-autobuild -b dirhtml "{{ sourcedir }}" "{{ builddir }}" {{ sphinxopts }} \
+        --port {{ http_port }} -a \
+        --watch "." \
+        --watch ../packages \
+        --re-ignore '/node_modules(/|$)' \
+        --re-ignore '/__pycache__(/|$)' \
+        --re-ignore '/\.pytest_cache(/|$)' \
+        --re-ignore '/dist(/|$)' \
+        --re-ignore '/_build(/|$)' \
+        --re-ignore '/packages/[^/]+/src/[^/]+/theme/[^/]+/static(/|$)'

--- a/packages/sphinx-vite-builder/src/sphinx_vite_builder/__init__.py
+++ b/packages/sphinx-vite-builder/src/sphinx_vite_builder/__init__.py
@@ -7,10 +7,8 @@ Two orthogonal entry points sharing one subprocess core:
    to :mod:`hatchling.build`. Consumer packages declare it via
    ``[build-system].build-backend = "sphinx_vite_builder.build"``.
 2. **Sphinx extension** registered by :func:`setup`. Hooks
-   ``builder-inited`` and ``build-finished`` so ``sphinx-build`` /
-   ``sphinx-autobuild`` automatically run vite — one-shot for prod, a
-   long-lived ``vite build --watch`` child process for autobuild —
-   with graceful teardown on signal / :data:`atexit`.
+   ``builder-inited`` to run ``pnpm exec vite build`` synchronously
+   before Sphinx's ``copy_static_files`` phase.
 
 Both heads consume the smart-subprocess core under
 :mod:`sphinx_vite_builder._internal`.
@@ -34,13 +32,10 @@ def setup(app: Sphinx) -> dict[str, t.Any]:
     """Register the Sphinx-extension head.
 
     Wires two config values (``sphinx_vite_builder_mode``,
-    ``sphinx_vite_builder_root``) and connects the ``builder-inited`` /
-    ``build-finished`` lifecycle hooks. Under ``sphinx-autobuild`` (or
-    when ``sphinx_vite_builder_mode = "dev"``) the ``builder-inited``
-    handler spawns ``pnpm exec vite build --watch`` against
-    ``sphinx_vite_builder_root``; under plain ``sphinx-build`` (or
-    ``mode = "prod"``) the handler is a no-op so production wheels
-    carry no Node runtime requirement.
+    ``sphinx_vite_builder_root``) and connects the ``builder-inited``
+    hook. The hook runs ``pnpm exec vite build`` synchronously;
+    ``sphinx_vite_builder_root`` controls whether vite runs at all
+    (unset → no-op, typical for installed wheels).
 
     Examples
     --------

--- a/packages/sphinx-vite-builder/src/sphinx_vite_builder/_internal/hooks.py
+++ b/packages/sphinx-vite-builder/src/sphinx_vite_builder/_internal/hooks.py
@@ -1,46 +1,31 @@
-"""Sphinx event handlers that drive the Vite watch lifecycle.
-
-The handlers live here (not in ``__init__.py``) so they're easy to unit
-test in isolation: tests mock a Sphinx-like app, call the handler
-directly, and assert against the process / bus instances stashed on
-``app._sphinx_vite_builder_*``.
+"""Sphinx event handlers that run the synchronous Vite build.
 
 Lifecycle:
 
-- ``builder-inited`` (:func:`on_builder_inited`) — resolve config; if
-  ``should_spawn``, start the bus, spawn the watch process,  and stash
-  both on ``app``. Idempotent: re-firing (sphinx-autobuild fires this
-  on every rebuild) finds the running process and returns.
-- ``build-finished`` (:func:`on_build_finished`) — no-op by default.
-  The watch process keeps running across rebuilds so Vite can
-  incrementally recompile on file changes. Teardown happens via
-  :data:`atexit` and signal handlers installed at first spawn.
+- ``builder-inited`` (:func:`on_builder_inited`) — resolve config, run
+  ``pnpm exec vite build`` synchronously (via :func:`run_vite_build`),
+  then return so Sphinx's static-file copying picks up fresh CSS/JS.
+- ``build-finished`` (:func:`on_build_finished`) — log exceptions; no
+  cleanup needed because the build is one-shot.
 
-Tear-down is the responsibility of :func:`teardown`, which is wired
-to ``atexit`` and to ``SIGINT`` / ``SIGTERM`` / ``SIGHUP``.
-
-The handlers are passive about command construction: they call
-:func:`sphinx_vite_builder._internal.process.vite_watch_command` for
-the default Vite argv. Tests monkey-patch that symbol when they want a
-fake-vite invocation.
+The build runs synchronously because under ``sphinx-autobuild``, each
+build executes in a short-lived subprocess (per
+:mod:`sphinx_autobuild.build`); an async vite watch would race
+Sphinx's ``copy_static_files`` phase and Sphinx would copy stale
+assets. A ~600ms blocking call per rebuild is the trade for
+guaranteed-fresh CSS/JS.
 """
 
 from __future__ import annotations
 
-import atexit
-import pathlib
-import signal
 import typing as t
-import weakref
 
 from sphinx.errors import ExtensionError
 from sphinx.util import logging as sphinx_logging
 
-from .bus import AsyncioBus
-from .config import Mode, SphinxViteBuilderConfig, detect_mode, resolve_vite_root
+from .config import SphinxViteBuilderConfig, detect_mode, resolve_vite_root
 from .errors import SphinxViteBuilderError
-from .process import AsyncProcess
-from .vite import pnpm_install_command, run_vite_build, vite_watch_command
+from .vite import run_vite_build
 
 if t.TYPE_CHECKING:
     from sphinx.application import Sphinx
@@ -51,17 +36,6 @@ if t.TYPE_CHECKING:
 # same way Sphinx's own messages do. The stdlib `logging.getLogger`
 # does not propagate by default in Sphinx contexts.
 logger = sphinx_logging.getLogger(__name__)
-
-_BUS_ATTR = "_sphinx_vite_builder_bus"
-_PROC_ATTR = "_sphinx_vite_builder_proc"
-_TEARDOWN_REGISTERED_ATTR = "_sphinx_vite_builder_teardown_registered"
-
-# Live (bus, proc) pairs that the global teardown handler should clean
-# up. Held weakly so a Sphinx app being garbage-collected doesn't keep
-# the bus thread alive.
-_active_handles: weakref.WeakValueDictionary[int, AsyncioBus] = (
-    weakref.WeakValueDictionary()
-)
 
 
 def _raise_as_extension_error(exc: Exception) -> t.NoReturn:
@@ -93,205 +67,46 @@ def _build_config(app: Sphinx) -> SphinxViteBuilderConfig:
     )
 
 
-def _ensure_node_modules(vite_root: pathlib.Path, bus: AsyncioBus) -> bool:
-    """Ensure ``<vite_root>/node_modules/`` exists; install if missing.
-
-    Closes the developer-workflow gap where ``git clean -fdx`` wipes
-    ``node_modules/`` and the next ``sphinx-autobuild`` would otherwise
-    spawn ``pnpm exec vite`` against a missing tree, exit immediately
-    with ``Command "vite" not found``, and silently leave the docs site
-    serving 404s for the theme's CSS + JS.
-
-    Returns ``True`` if ``node_modules/`` exists (or was installed
-    successfully); ``False`` if the install ran but exited non-zero,
-    which signals to :func:`on_builder_inited` to skip the vite-watch
-    spawn rather than burn cycles on a guaranteed-failed
-    ``pnpm exec vite``.
-    """
-    if (vite_root / "node_modules").exists():
-        return True
-
-    install_cmd = pnpm_install_command()
-    logger.info(
-        "[vite] node_modules/ missing in %s; running `%s`",
-        vite_root,
-        " ".join(install_cmd),
-    )
-    install_proc = AsyncProcess(label="pnpm-install", logger=logger)
-    bus.call_sync(install_proc.start(install_cmd, cwd=vite_root))
-    returncode = bus.call_sync(install_proc.wait())
-    if returncode != 0:
-        logger.warning(
-            "[vite] pnpm install failed (exit %d) in %s — skipping vite "
-            "spawn; run the install manually and restart sphinx-autobuild",
-            returncode,
-            vite_root,
-        )
-        return False
-    logger.info("[vite] pnpm install complete; proceeding to vite-watch spawn")
-    return True
-
-
 def on_builder_inited(app: Sphinx) -> None:
     """``builder-inited`` event handler.
 
-    DEV mode (``sphinx-autobuild``) spawns the long-running Vite watch
-    process; PROD mode (plain ``sphinx-build``) runs a one-shot
-    ``pnpm exec vite build`` and blocks until it finishes so the
-    subsequent Sphinx build sees fresh CSS/JS in ``static/``. Idempotent
-    across multiple builder-inited firings (sphinx-autobuild re-fires
-    this on every rebuild).
+    Runs ``pnpm exec vite build`` synchronously and blocks until it
+    finishes. Both PROD (plain ``sphinx-build``) and DEV
+    (``sphinx-autobuild``) take this same path: each ``sphinx-autobuild``
+    rebuild is a fresh subprocess, so a synchronous one-shot vite per
+    rebuild is the correct primitive — it guarantees Sphinx's
+    ``copy_static_files`` phase sees fresh CSS/JS rather than racing an
+    async watch that hasn't finished its initial build yet.
 
-    If ``<vite_root>/node_modules/`` is missing (typical after
-    ``git clean -fdx``), runs ``pnpm install --frozen-lockfile``
-    synchronously first so ``pnpm exec vite`` resolves on first try.
+    :func:`run_vite_build` handles the ``SPHINX_VITE_BUILDER_SKIP``
+    escape hatch, the ``web/``-absent short-circuit, missing
+    ``node_modules`` auto-install, and fast-fail diagnostics
+    (``PnpmMissingError`` / ``NodeModulesInstallError`` /
+    ``ViteFailedError``) internally; this hook just funnels Sphinx's
+    extension-error path through ``_raise_as_extension_error``.
     """
     config = _build_config(app)
     if config.vite_root is None:
-        # No vite_root configured → nothing to orchestrate. Both modes
-        # treat this as "the consumer doesn't have a vite project to
-        # build" (typical when running off an installed wheel).
+        # No vite_root configured → nothing to orchestrate (typical when
+        # running off an installed wheel with the static tree pre-baked).
         return
 
-    if config.mode is Mode.PROD:
-        # One-shot build via the shared backend orchestration. Same
-        # short-circuits (SPHINX_VITE_BUILDER_SKIP, web/-absent) and
-        # same fast-fail diagnostics as the PEP 517 backend uses.
-        # ``run_vite_build`` resolves ``web/`` relative to its
-        # ``project_root`` argument, so pass the parent of vite_root.
-        try:
-            run_vite_build(project_root=config.vite_root.parent)
-        except SphinxViteBuilderError as exc:
-            _raise_as_extension_error(exc)
-        return
-
-    existing_proc: AsyncProcess | None = getattr(app, _PROC_ATTR, None)
-    if existing_proc is not None and existing_proc.is_running:
-        # sphinx-autobuild's repeated builder-inited; the watch is
-        # already running, leave it alone.
-        return
-
-    bus = getattr(app, _BUS_ATTR, None)
-    if bus is None:
-        bus = AsyncioBus()
-        bus.start()
-        setattr(app, _BUS_ATTR, bus)
-        _active_handles[id(app)] = bus
-
-    if config.vite_root is None:
-        # `should_spawn` already guards this, but tighten for type checkers.
-        msg = "should_spawn was True but vite_root resolved to None"
-        raise RuntimeError(msg)
-
-    if not _ensure_node_modules(config.vite_root, bus):
-        # Install failed; warning was already logged. Don't try to
-        # spawn vite — pnpm exec would fail the same way.
-        return
-
-    proc = AsyncProcess(label="vite", logger=logger)
-    setattr(app, _PROC_ATTR, proc)
-
-    command = vite_watch_command()
-    logger.info("[vite] spawning %s in %s", " ".join(command), config.vite_root)
+    # ``run_vite_build`` resolves ``web/`` relative to its
+    # ``project_root`` argument, so pass the parent of vite_root.
     try:
-        bus.call_sync(proc.start(command, cwd=config.vite_root))
-    except (SphinxViteBuilderError, OSError) as exc:
-        # OSError covers the FileNotFoundError that
-        # ``asyncio.create_subprocess_exec`` raises when the package
-        # manager (pnpm) is not on PATH. SphinxViteBuilderError covers
-        # any typed diagnostic raised through the bus from inside
-        # AsyncProcess.start. Both get the same modname-attributed
-        # ExtensionError treatment so users see "Extension error
-        # (sphinx_vite_builder)" instead of the internal module path.
+        run_vite_build(project_root=config.vite_root.parent)
+    except SphinxViteBuilderError as exc:
         _raise_as_extension_error(exc)
-
-    if not getattr(app, _TEARDOWN_REGISTERED_ATTR, False):
-        _install_teardown_handlers(app)
-        setattr(app, _TEARDOWN_REGISTERED_ATTR, True)
 
 
 def on_build_finished(app: Sphinx, exception: BaseException | None) -> None:
     """``build-finished`` event handler.
 
-    Deliberately a no-op: keeping the watch alive across rebuilds is
-    the whole point of the orchestration. Teardown happens via signal
-    handlers and the :mod:`atexit` registration installed at first
-    spawn.
-
-    Logs the exception (if any) for context, but does not interfere
-    with Sphinx's own error reporting.
+    No-op for the common case. Logs the exception (if any) for
+    context, but does not interfere with Sphinx's own error reporting.
     """
     if exception is not None:
         logger.debug(
-            "[vite] sphinx build finished with exception (%s); leaving watch alive",
+            "[vite] sphinx build finished with exception: %s",
             exception,
         )
-
-
-def teardown(app: Sphinx, *, terminate_timeout: float = 5.0) -> None:
-    """Stop the Vite watch and tear down the bus for ``app``.
-
-    Idempotent: safe to call from multiple signal sources (atexit +
-    SIGINT) without double-stop errors.
-    """
-    proc: AsyncProcess | None = getattr(app, _PROC_ATTR, None)
-    bus: AsyncioBus | None = getattr(app, _BUS_ATTR, None)
-    if proc is None and bus is None:
-        return
-
-    if proc is not None and bus is not None:
-        try:
-            bus.call_sync(proc.terminate(timeout=terminate_timeout))
-        except Exception as exc:
-            logger.warning("[vite] terminate raised during teardown: %s", exc)
-
-    if bus is not None:
-        bus.stop(timeout=terminate_timeout)
-
-    setattr(app, _PROC_ATTR, None)
-    setattr(app, _BUS_ATTR, None)
-
-
-def _install_teardown_handlers(app: Sphinx) -> None:
-    """Wire :data:`atexit` + signal handlers to tear down ``app``'s watch.
-
-    Uses a weak reference to the app so a long-lived Python process
-    holding the handler doesn't keep the app alive past its natural
-    lifetime.
-    """
-    app_ref = weakref.ref(app)
-
-    def _handle_atexit() -> None:
-        live_app = app_ref()
-        if live_app is not None:
-            teardown(live_app)
-
-    atexit.register(_handle_atexit)
-
-    previous_handlers: dict[int, t.Any] = {}
-    for sig_name in ("SIGINT", "SIGTERM", "SIGHUP"):
-        sig = getattr(signal, sig_name, None)
-        if sig is None:
-            continue  # Windows lacks SIGHUP, etc.
-
-        def _make_handler(
-            sig: int,
-            previous: t.Any = None,
-        ) -> t.Callable[[int, t.Any], None]:
-            def _handle(signum: int, frame: t.Any) -> None:
-                live_app = app_ref()
-                if live_app is not None:
-                    teardown(live_app)
-                if callable(previous):
-                    previous(signum, frame)
-                # Re-raise the signal once cleanup is done so the
-                # default behavior (process exit) follows.
-                if previous in (signal.SIG_DFL, None):
-                    signal.signal(signum, signal.SIG_DFL)
-                    signal.raise_signal(signum)
-
-            return _handle
-
-        previous = signal.getsignal(sig)
-        previous_handlers[sig] = previous
-        signal.signal(sig, _make_handler(sig, previous))

--- a/tests/test_sphinx_vite_builder_extension_integration.py
+++ b/tests/test_sphinx_vite_builder_extension_integration.py
@@ -1,17 +1,15 @@
 """Integration test: sphinx_vite_builder wired into a real Sphinx build.
 
 Exercises the full path — entry-point loaded from the Sphinx extensions
-list, ``setup()`` invoked, ``builder-inited`` fires, the hook spawns
-:class:`AsyncProcess` against a fake-vite script, ``build-finished`` fires
-(no-op), and the test explicitly tears down. The unit tests in
+list, ``setup()`` invoked, ``builder-inited`` fires and runs the
+synchronous vite build (monkey-patched here to a no-op recorder),
+``build-finished`` fires (no-op). The unit tests in
 ``test_sphinx_vite_builder_hooks.py`` cover the same surface against a
 hand-rolled FakeApp; this file proves the wiring through Sphinx itself.
 """
 
 from __future__ import annotations
 
-import shutil
-import sys
 import textwrap
 import typing as t
 
@@ -28,12 +26,6 @@ if t.TYPE_CHECKING:
     import pathlib
 
 
-pytestmark = pytest.mark.skipif(
-    shutil.which(sys.executable.split("/")[-1]) is None and not sys.executable,
-    reason="No Python interpreter found on PATH for the fake-vite child",
-)
-
-
 _INDEX_RST = textwrap.dedent(
     """\
     Integration Demo
@@ -44,19 +36,24 @@ _INDEX_RST = textwrap.dedent(
 )
 
 
-def _conf_py(*, fake_vite_root: str, fake_vite_argv: tuple[str, ...]) -> str:
-    """Build a conf.py that wires sphinx_vite_builder + monkey-patches the watch.
+def _conf_py_with_recorder(*, fake_vite_root: str) -> str:
+    """Build a conf.py that wires sphinx_vite_builder and records vite calls.
 
-    The monkey-patch happens at conf.py time (which runs before
-    builder-inited fires), via
-    ``sphinx_vite_builder._internal.hooks.vite_watch_command`` being
-    replaced. The hook reads it from its own module-level rebinding done
-    at import time, so we patch *that* name.
+    Replaces ``sphinx_vite_builder._internal.hooks.run_vite_build`` with
+    a recorder that appends to ``_recorded_vite_calls`` on the module,
+    so the test can verify the hook actually fired without spawning a
+    real subprocess.
     """
     return textwrap.dedent(
         f"""\
         import sphinx_vite_builder._internal.hooks as _svb_hooks
-        _svb_hooks.vite_watch_command = lambda: {fake_vite_argv!r}
+
+        _svb_hooks._recorded_vite_calls = []
+
+        def _recorder(*, project_root):
+            _svb_hooks._recorded_vite_calls.append(project_root)
+
+        _svb_hooks.run_vite_build = _recorder
 
         extensions = ["sphinx_vite_builder"]
         html_theme = "basic"
@@ -69,35 +66,16 @@ def _conf_py(*, fake_vite_root: str, fake_vite_argv: tuple[str, ...]) -> str:
 
 
 @pytest.mark.integration
-def test_sphinx_build_spawns_via_extension(tmp_path: pathlib.Path) -> None:
-    """A Sphinx build with the extension active spawns the watch process."""
+def test_sphinx_build_runs_vite_build_via_extension(tmp_path: pathlib.Path) -> None:
+    """A Sphinx build with the extension active calls ``run_vite_build``."""
     fake_vite_dir = tmp_path / "fake-vite-root"
     fake_vite_dir.mkdir()
-    (fake_vite_dir / "package.json").write_text('{"name": "fake-vite-integration"}\n')
-    # Pre-create node_modules/ so _ensure_node_modules short-circuits the
-    # auto-install path (CI runners don't have pnpm on PATH).
-    (fake_vite_dir / "node_modules").mkdir()
-    fake_script = fake_vite_dir / "fake_vite.py"
-    fake_script.write_text(
-        textwrap.dedent(
-            """\
-            import time
-            print("vite ready", flush=True)
-            while True:
-                time.sleep(0.1)
-            """,
-        ),
-    )
 
-    fake_vite_argv = (sys.executable, str(fake_script))
     scenario = SphinxScenario(
         files=(
             ScenarioFile(
                 "conf.py",
-                _conf_py(
-                    fake_vite_root=str(fake_vite_dir),
-                    fake_vite_argv=fake_vite_argv,
-                ),
+                _conf_py_with_recorder(fake_vite_root=str(fake_vite_dir)),
             ),
             ScenarioFile("index.rst", _INDEX_RST),
         ),
@@ -114,31 +92,37 @@ def test_sphinx_build_spawns_via_extension(tmp_path: pathlib.Path) -> None:
         ),
     )
 
-    proc = getattr(result.app, "_sphinx_vite_builder_proc", None)
-    bus = getattr(result.app, "_sphinx_vite_builder_bus", None)
-    try:
-        assert proc is not None, "hooks did not stash an AsyncProcess on the app"
-        assert bus is not None, "hooks did not stash an AsyncioBus on the app"
-        assert proc.is_running, "AsyncProcess exited before the test could observe it"
-        assert bus.is_running, "AsyncioBus stopped before the test could observe it"
-    finally:
-        # Explicit teardown — atexit-based cleanup runs at interpreter
-        # exit, which is fine for production but leaves the test
-        # process holding the bus thread until then.
-        from sphinx_vite_builder._internal import hooks
+    from sphinx_vite_builder._internal import hooks
 
-        hooks.teardown(result.app, terminate_timeout=2.0)
+    calls = getattr(hooks, "_recorded_vite_calls", None)
+    assert calls is not None, "conf.py recorder did not initialise"
+    assert len(calls) >= 1, "run_vite_build was not invoked by the extension"
+    # ``sphinx_vite_builder_root`` was the fake_vite_dir (the ``web/``
+    # equivalent); the hook should pass its *parent* as project_root.
+    assert calls[0] == fake_vite_dir.parent
+
+    # Sphinx build itself should still succeed.
+    assert result.app is not None
 
 
 @pytest.mark.integration
-def test_sphinx_build_no_op_in_prod_mode(tmp_path: pathlib.Path) -> None:
-    """`sphinx_vite_builder_mode = "prod"` builds without spawning anything."""
+def test_sphinx_build_no_op_when_root_unset(tmp_path: pathlib.Path) -> None:
+    """Without ``sphinx_vite_builder_root`` the build skips vite entirely."""
     scenario = SphinxScenario(
         files=(
             ScenarioFile(
                 "conf.py",
                 textwrap.dedent(
                     """\
+                    import sphinx_vite_builder._internal.hooks as _svb_hooks
+
+                    _svb_hooks._recorded_vite_calls = []
+
+                    def _recorder(*, project_root):
+                        _svb_hooks._recorded_vite_calls.append(project_root)
+
+                    _svb_hooks.run_vite_build = _recorder
+
                     extensions = ["sphinx_vite_builder"]
                     html_theme = "basic"
                     master_doc = "index"
@@ -151,11 +135,13 @@ def test_sphinx_build_no_op_in_prod_mode(tmp_path: pathlib.Path) -> None:
         ),
     )
 
-    result: SharedSphinxResult = build_isolated_sphinx_result(
+    build_isolated_sphinx_result(
         cache_root=tmp_path / "scenario-cache",
         tmp_path=tmp_path / "scenario-tmp",
         scenario=scenario,
         purge_modules=("sphinx_vite_builder",),
     )
-    assert getattr(result.app, "_sphinx_vite_builder_proc", None) is None
-    assert getattr(result.app, "_sphinx_vite_builder_bus", None) is None
+
+    from sphinx_vite_builder._internal import hooks
+
+    assert getattr(hooks, "_recorded_vite_calls", []) == []

--- a/tests/test_sphinx_vite_builder_hooks.py
+++ b/tests/test_sphinx_vite_builder_hooks.py
@@ -1,20 +1,16 @@
 """Tests for :mod:`sphinx_vite_builder._internal.hooks`.
 
-The hooks layer wires an :class:`AsyncProcess` to Sphinx's lifecycle
-events. Tests use a thin Sphinx-app stand-in (with ``.config`` and the
-four attributes the hooks set) and a fake-vite Python script in
-``tmp_path`` so each test can exercise the real subprocess +
-``AsyncioBus`` + ``AsyncProcess`` chain end-to-end without booting a
-full Sphinx build.
+The hooks layer wires :func:`run_vite_build` to Sphinx's lifecycle.
+Tests use a thin Sphinx-app stand-in (with ``.config``) and monkey-patch
+``hooks.run_vite_build`` so each test runs without spawning a real
+subprocess.
 """
 
 from __future__ import annotations
 
 import dataclasses
 import pathlib
-import sys
-import textwrap
-import time
+import typing as t
 
 import pytest
 from sphinx.errors import ExtensionError
@@ -22,6 +18,7 @@ from sphinx_vite_builder._internal import hooks
 from sphinx_vite_builder._internal.errors import (
     PnpmMissingError,
     SphinxViteBuilderError,
+    ViteFailedError,
 )
 
 
@@ -35,571 +32,157 @@ class _FakeConfig:
 
 @dataclasses.dataclass
 class _FakeApp:
-    """Minimal stand-in for ``sphinx.application.Sphinx``.
-
-    Carries only the surface the hooks touch: a ``config`` namespace
-    and the few private attributes the hooks ``setattr`` onto the app
-    (bus, proc, teardown-registered flag).
-    """
+    """Minimal stand-in for ``sphinx.application.Sphinx``."""
 
     config: _FakeConfig = dataclasses.field(default_factory=_FakeConfig)
-
-
-def _write_fake_vite(
-    tmp_path: pathlib.Path, *, body: str, with_node_modules: bool = True
-) -> pathlib.Path:
-    """Write a fake-vite script + a stub package.json at ``tmp_path``.
-
-    Creates ``node_modules/`` by default so :func:`hooks._ensure_node_modules`
-    short-circuits the auto-install path. Tests that exercise the install
-    path explicitly pass ``with_node_modules=False`` and arrange their own
-    ``pnpm_install_command`` patch.
-    """
-    (tmp_path / "package.json").write_text('{"name": "fake-vite-root"}\n')
-    if with_node_modules:
-        (tmp_path / "node_modules").mkdir(exist_ok=True)
-    script = tmp_path / "fake_vite.py"
-    script.write_text(textwrap.dedent(body))
-    return script
-
-
-def _patch_vite_command(monkeypatch: pytest.MonkeyPatch, script: pathlib.Path) -> None:
-    """Replace ``vite_watch_command()`` with one that runs ``script``."""
-
-    def _fake_command() -> tuple[str, ...]:
-        return (sys.executable, str(script))
-
-    # Patch where hooks reads the symbol from (its own module namespace).
-    monkeypatch.setattr(hooks, "vite_watch_command", _fake_command)
-
-
-def _patch_install_command(
-    monkeypatch: pytest.MonkeyPatch, script: pathlib.Path
-) -> None:
-    """Replace ``pnpm_install_command()`` with one that runs ``script``."""
-
-    def _fake_command() -> tuple[str, ...]:
-        return (sys.executable, str(script))
-
-    monkeypatch.setattr(hooks, "pnpm_install_command", _fake_command)
-
-
-@pytest.fixture
-def long_running_fake_vite(
-    tmp_path: pathlib.Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> _FakeApp:
-    """Fake-vite that loops forever; a teardown is required to clean up."""
-    script = _write_fake_vite(
-        tmp_path,
-        body="""\
-        import sys, time
-        # Print one ready-line so a human running this can see progress.
-        print("vite watching", flush=True)
-        while True:
-            time.sleep(0.1)
-        """,
-    )
-    _patch_vite_command(monkeypatch, script)
-    return _FakeApp(
-        config=_FakeConfig(
-            sphinx_vite_builder_mode="dev",
-            sphinx_vite_builder_root=str(tmp_path),
-        ),
-    )
-
-
-def test_on_builder_inited_no_op_in_prod_mode(
-    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """`mode="prod"` → no process spawned, no bus started."""
-    app = _FakeApp(
-        config=_FakeConfig(
-            sphinx_vite_builder_mode="prod",
-            sphinx_vite_builder_root=str(tmp_path),
-        ),
-    )
-
-    def _fail() -> tuple[str, ...]:
-        msg = "vite_watch_command should not be called in prod mode"
-        raise AssertionError(msg)
-
-    monkeypatch.setattr(hooks, "vite_watch_command", _fail)
-    hooks.on_builder_inited(app)  # type: ignore[arg-type]
-    assert getattr(app, hooks._PROC_ATTR, None) is None
-    assert getattr(app, hooks._BUS_ATTR, None) is None
-
-
-def test_on_builder_inited_runs_one_shot_in_prod_mode(
-    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """`mode="prod"` with a vite_root → one-shot run_vite_build, no spawn.
-
-    Covers the PROD branch added alongside the placeholder rewrite: under
-    plain ``sphinx-build`` the extension delegates to the same orchestration
-    primitive the PEP 517 backend uses, blocking the build until vite
-    finishes and never spawning the long-running watch.
-    """
-    captured: list[pathlib.Path | None] = []
-
-    def _capture(
-        project_root: pathlib.Path | None = None,
-        *,
-        package_manager: str = "pnpm",
-    ) -> None:
-        del package_manager
-        captured.append(project_root)
-
-    monkeypatch.setattr(hooks, "run_vite_build", _capture)
-
-    vite_root = tmp_path / "web"
-    vite_root.mkdir()
-    app = _FakeApp(
-        config=_FakeConfig(
-            sphinx_vite_builder_mode="prod",
-            sphinx_vite_builder_root=str(vite_root),
-        ),
-    )
-
-    hooks.on_builder_inited(app)  # type: ignore[arg-type]
-
-    # `run_vite_build` resolves `web/` relative to its `project_root`
-    # arg, so the hook passes the parent of vite_root.
-    assert captured == [vite_root.parent.resolve()]
-    # PROD path is one-shot: no watch process, no bus.
-    assert getattr(app, hooks._PROC_ATTR, None) is None
-    assert getattr(app, hooks._BUS_ATTR, None) is None
 
 
 def test_on_builder_inited_no_op_when_root_is_none(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """`mode="dev"` but no root → still no spawn (config.should_spawn is False)."""
-    app = _FakeApp(
-        config=_FakeConfig(
-            sphinx_vite_builder_mode="dev",
-            sphinx_vite_builder_root=None,
-        ),
-    )
+    """No ``sphinx_vite_builder_root`` → ``run_vite_build`` never called."""
+    app = _FakeApp(config=_FakeConfig(sphinx_vite_builder_root=None))
 
-    def _fail() -> tuple[str, ...]:
-        msg = "vite_watch_command should not be called when root is None"
+    def _fail(**_: t.Any) -> None:
+        msg = "run_vite_build should not be called when vite_root is None"
         raise AssertionError(msg)
 
-    monkeypatch.setattr(hooks, "vite_watch_command", _fail)
+    monkeypatch.setattr(hooks, "run_vite_build", _fail)
     hooks.on_builder_inited(app)  # type: ignore[arg-type]
-    assert getattr(app, hooks._PROC_ATTR, None) is None
 
 
-def test_on_builder_inited_spawns_when_should_spawn(
-    long_running_fake_vite: _FakeApp,
-) -> None:
-    """A dev-mode app with a real root spawns the watch."""
-    app = long_running_fake_vite
-    try:
-        hooks.on_builder_inited(app)  # type: ignore[arg-type]
-        proc = getattr(app, hooks._PROC_ATTR, None)
-        bus = getattr(app, hooks._BUS_ATTR, None)
-        assert proc is not None
-        assert bus is not None
-        assert bus.is_running
-        # Give the child a moment to actually spawn before asserting.
-        deadline = time.monotonic() + 1.0
-        while not proc.is_running and time.monotonic() < deadline:
-            time.sleep(0.01)
-        assert proc.is_running
-    finally:
-        hooks.teardown(app, terminate_timeout=2.0)  # type: ignore[arg-type]
-
-
-def test_on_builder_inited_is_idempotent_on_refire(
-    long_running_fake_vite: _FakeApp,
-) -> None:
-    """sphinx-autobuild's repeated builder-inited doesn't double-spawn."""
-    app = long_running_fake_vite
-    try:
-        hooks.on_builder_inited(app)  # type: ignore[arg-type]
-        first_proc = getattr(app, hooks._PROC_ATTR, None)
-        first_pid = first_proc.pid if first_proc else None
-
-        # Re-fire: simulating sphinx-autobuild's behavior.
-        hooks.on_builder_inited(app)  # type: ignore[arg-type]
-        second_proc = getattr(app, hooks._PROC_ATTR, None)
-        second_pid = second_proc.pid if second_proc else None
-
-        assert first_proc is second_proc
-        assert first_pid == second_pid
-    finally:
-        hooks.teardown(app, terminate_timeout=2.0)  # type: ignore[arg-type]
-
-
-def test_on_build_finished_leaves_watch_running(
-    long_running_fake_vite: _FakeApp,
-) -> None:
-    """build-finished is a no-op: the watch keeps running for the next rebuild."""
-    app = long_running_fake_vite
-    try:
-        hooks.on_builder_inited(app)  # type: ignore[arg-type]
-        proc = getattr(app, hooks._PROC_ATTR, None)
-        assert proc is not None
-        deadline = time.monotonic() + 1.0
-        while not proc.is_running and time.monotonic() < deadline:
-            time.sleep(0.01)
-        assert proc.is_running
-
-        hooks.on_build_finished(app, exception=None)  # type: ignore[arg-type]
-        # Still running after build-finished.
-        assert proc.is_running
-    finally:
-        hooks.teardown(app, terminate_timeout=2.0)  # type: ignore[arg-type]
-
-
-def test_teardown_terminates_process_and_stops_bus(
-    long_running_fake_vite: _FakeApp,
-) -> None:
-    """Explicit teardown stops both the process and the bus, idempotently."""
-    app = long_running_fake_vite
-    hooks.on_builder_inited(app)  # type: ignore[arg-type]
-    proc = getattr(app, hooks._PROC_ATTR, None)
-    bus = getattr(app, hooks._BUS_ATTR, None)
-    assert proc is not None and bus is not None
-
-    hooks.teardown(app, terminate_timeout=2.0)  # type: ignore[arg-type]
-
-    assert not proc.is_running
-    assert not bus.is_running
-    assert getattr(app, hooks._PROC_ATTR, None) is None
-    assert getattr(app, hooks._BUS_ATTR, None) is None
-
-    # Calling teardown again is a no-op.
-    hooks.teardown(app, terminate_timeout=2.0)  # type: ignore[arg-type]
-
-
-def test_teardown_no_op_when_never_spawned() -> None:
-    """Teardown on an app that never reached should_spawn does nothing harmful."""
-    app = _FakeApp()
-    hooks.teardown(app)  # type: ignore[arg-type]
-
-
-def test_on_build_finished_logs_exception(
-    long_running_fake_vite: _FakeApp,
-) -> None:
-    """An exception passed to build-finished surfaces at DEBUG (not WARNING).
-
-    Sphinx's logger setup (memory handlers, namespace prefix) interacts
-    with pytest's ``caplog`` in test-order-dependent ways once any
-    Sphinx scenario fixture has initialized a real Sphinx app. Sidestep
-    by attaching our own handler directly to the underlying stdlib
-    Logger that ``sphinx.util.logging.getLogger`` wraps.
-    """
-    import logging
-
-    app = long_running_fake_vite
-    captured: list[logging.LogRecord] = []
-
-    class _CaptureHandler(logging.Handler):
-        def emit(self, record: logging.LogRecord) -> None:
-            captured.append(record)
-
-    handler = _CaptureHandler(level=logging.DEBUG)
-    underlying = logging.getLogger("sphinx.sphinx_vite_builder._internal.hooks")
-    underlying.addHandler(handler)
-    underlying.setLevel(logging.DEBUG)
-
-    try:
-        hooks.on_builder_inited(app)  # type: ignore[arg-type]
-        hooks.on_build_finished(
-            app,  # type: ignore[arg-type]
-            exception=RuntimeError("sphinx fell over"),
-        )
-        assert any("sphinx fell over" in r.getMessage() for r in captured), [
-            r.getMessage() for r in captured
-        ]
-    finally:
-        underlying.removeHandler(handler)
-        hooks.teardown(app, terminate_timeout=2.0)  # type: ignore[arg-type]
-
-
-def test_on_builder_inited_skips_install_when_node_modules_present(
-    tmp_path: pathlib.Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Pre-existing node_modules/ → no install attempt; vite spawns directly."""
-    # Pre-create node_modules so _ensure_node_modules sees it as present.
-    (tmp_path / "node_modules").mkdir()
-    vite_script = _write_fake_vite(
-        tmp_path,
-        body="""\
-        import time
-        print("vite watching", flush=True)
-        while True:
-            time.sleep(0.1)
-        """,
-    )
-    _patch_vite_command(monkeypatch, vite_script)
-
-    def _fail_install() -> tuple[str, ...]:
-        msg = "pnpm_install_command should not be called when node_modules/ exists"
-        raise AssertionError(msg)
-
-    monkeypatch.setattr(hooks, "pnpm_install_command", _fail_install)
-
-    app = _FakeApp(
-        config=_FakeConfig(
-            sphinx_vite_builder_mode="dev",
-            sphinx_vite_builder_root=str(tmp_path),
-        ),
-    )
-    try:
-        hooks.on_builder_inited(app)  # type: ignore[arg-type]
-        proc = getattr(app, hooks._PROC_ATTR, None)
-        assert proc is not None, "vite should have spawned"
-    finally:
-        hooks.teardown(app, terminate_timeout=2.0)  # type: ignore[arg-type]
-
-
-def test_on_builder_inited_runs_install_when_node_modules_missing(
-    tmp_path: pathlib.Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Missing node_modules/ → install runs (and creates it), then vite spawns.
-
-    The install marker file (``installed.flag``) is the deterministic proof
-    the fake-pnpm script ran; ``node_modules/`` creation is the side-effect
-    that silences subsequent _ensure_node_modules calls on a re-fire.
-    """
-    install_marker = tmp_path / "installed.flag"
-    install_script = tmp_path / "fake_pnpm.py"
-    install_script.write_text(
-        textwrap.dedent(
-            f"""\
-            import pathlib
-            (pathlib.Path({str(install_marker)!r})).write_text("ran")
-            (pathlib.Path({str(tmp_path / "node_modules")!r})).mkdir()
-            """,
-        ),
-    )
-    vite_script = _write_fake_vite(
-        tmp_path,
-        with_node_modules=False,
-        body="""\
-        import time
-        print("vite watching", flush=True)
-        while True:
-            time.sleep(0.1)
-        """,
-    )
-    _patch_vite_command(monkeypatch, vite_script)
-    _patch_install_command(monkeypatch, install_script)
-
-    app = _FakeApp(
-        config=_FakeConfig(
-            sphinx_vite_builder_mode="dev",
-            sphinx_vite_builder_root=str(tmp_path),
-        ),
-    )
-    try:
-        hooks.on_builder_inited(app)  # type: ignore[arg-type]
-        assert install_marker.exists(), "fake-pnpm install should have run"
-        assert (tmp_path / "node_modules").exists(), (
-            "install should have created node_modules"
-        )
-        proc = getattr(app, hooks._PROC_ATTR, None)
-        assert proc is not None, "vite should have spawned after successful install"
-    finally:
-        hooks.teardown(app, terminate_timeout=2.0)  # type: ignore[arg-type]
-
-
-def test_on_builder_inited_skips_vite_when_install_fails(
-    tmp_path: pathlib.Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Install exits non-zero → vite is not spawned; warning is logged."""
-    install_script = tmp_path / "fake_pnpm.py"
-    install_script.write_text(
-        textwrap.dedent(
-            """\
-            import sys
-            print("simulated pnpm-install failure", flush=True)
-            sys.exit(1)
-            """,
-        ),
-    )
-
-    def _fail_vite() -> tuple[str, ...]:
-        msg = "vite_watch_command should not be called after install failure"
-        raise AssertionError(msg)
-
-    monkeypatch.setattr(hooks, "vite_watch_command", _fail_vite)
-    _patch_install_command(monkeypatch, install_script)
-
-    # We still need a package.json so config.should_spawn passes the
-    # vite_root resolution check.
-    (tmp_path / "package.json").write_text('{"name": "fake-vite-root"}\n')
-
-    app = _FakeApp(
-        config=_FakeConfig(
-            sphinx_vite_builder_mode="dev",
-            sphinx_vite_builder_root=str(tmp_path),
-        ),
-    )
-    hooks.on_builder_inited(app)  # type: ignore[arg-type]
-    # No vite process should have been set on the app.
-    assert getattr(app, hooks._PROC_ATTR, None) is None, (
-        "vite must not be spawned after a failed install"
-    )
-    hooks.teardown(app, terminate_timeout=2.0)  # type: ignore[arg-type]
-
-
-def test_private_attr_names_are_stable() -> None:
-    """The private attribute names the hooks set on app are part of the contract."""
-    assert hooks._BUS_ATTR == "_sphinx_vite_builder_bus"
-    assert hooks._PROC_ATTR == "_sphinx_vite_builder_proc"
-
-
-_PRIVATE_ATTRS_TYPED: tuple[str, str, str] = (
-    hooks._BUS_ATTR,
-    hooks._PROC_ATTR,
-    hooks._TEARDOWN_REGISTERED_ATTR,
-)
-
-
-def test_all_private_attrs_share_prefix() -> None:
-    """Every private attribute starts with `_sphinx_vite_builder_`."""
-    for attr in _PRIVATE_ATTRS_TYPED:
-        assert attr.startswith("_sphinx_vite_builder_"), attr
-
-
-def test_prod_mode_failure_raises_extension_error_with_modname(
+def test_on_builder_inited_calls_run_vite_build_with_project_root(
     tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A typed diagnostic from PROD-mode run_vite_build → ExtensionError.
+    """When a root is configured, ``run_vite_build`` receives its parent.
 
-    Sphinx's EventManager.emit() auto-wraps non-SphinxError exceptions
-    raised from event handlers using the handler's __module__ as the
-    modname — which would surface to users as "Extension error
-    (sphinx_vite_builder._internal.hooks)". The wrap-with-modname in
-    on_builder_inited keeps the user-facing attribution clean
-    ("Extension error (sphinx_vite_builder)") and preserves the original
-    diagnostic via orig_exc.
+    ``run_vite_build`` resolves ``web/`` relative to its
+    ``project_root`` argument, and ``sphinx_vite_builder_root`` points
+    at the ``web/`` dir itself — so the hook must pass ``web/``'s
+    parent.
     """
+    web_dir = tmp_path / "web"
+    web_dir.mkdir()
 
-    def _raise_pnpm_missing(
-        project_root: pathlib.Path | None = None,
-        *,
-        package_manager: str = "pnpm",
-    ) -> None:
-        del project_root, package_manager
-        msg = "pnpm is not on PATH"
-        raise PnpmMissingError(msg)
+    captured: dict[str, pathlib.Path | None] = {"project_root": None}
 
-    monkeypatch.setattr(hooks, "run_vite_build", _raise_pnpm_missing)
+    def _capture(*, project_root: pathlib.Path) -> None:
+        captured["project_root"] = project_root
 
-    vite_root = tmp_path / "web"
-    vite_root.mkdir()
+    monkeypatch.setattr(hooks, "run_vite_build", _capture)
+
     app = _FakeApp(
         config=_FakeConfig(
-            sphinx_vite_builder_mode="prod",
-            sphinx_vite_builder_root=str(vite_root),
+            sphinx_vite_builder_mode="auto",
+            sphinx_vite_builder_root=str(web_dir),
         ),
     )
+    hooks.on_builder_inited(app)  # type: ignore[arg-type]
 
+    assert captured["project_root"] == web_dir.parent
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["auto", "dev", "prod"],
+    ids=["mode-auto", "mode-dev", "mode-prod"],
+)
+def test_on_builder_inited_runs_one_shot_in_every_mode(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch, mode: str
+) -> None:
+    """The synchronous one-shot fires in every mode (auto / dev / prod).
+
+    Both PROD and DEV-under-sphinx-autobuild funnel through
+    :func:`run_vite_build` — there is no mode-specific spawn path.
+    """
+    web_dir = tmp_path / "web"
+    web_dir.mkdir()
+
+    calls: list[pathlib.Path] = []
+    monkeypatch.setattr(
+        hooks,
+        "run_vite_build",
+        lambda *, project_root: calls.append(project_root),
+    )
+
+    app = _FakeApp(
+        config=_FakeConfig(
+            sphinx_vite_builder_mode=mode,
+            sphinx_vite_builder_root=str(web_dir),
+        ),
+    )
+    hooks.on_builder_inited(app)  # type: ignore[arg-type]
+
+    assert calls == [web_dir.parent]
+
+
+@pytest.mark.parametrize(
+    "exc_factory",
+    [
+        lambda: PnpmMissingError("pnpm not on PATH"),
+        lambda: ViteFailedError("vite exit 1"),
+        lambda: SphinxViteBuilderError("anything else"),
+    ],
+    ids=["PnpmMissingError", "ViteFailedError", "SphinxViteBuilderError"],
+)
+def test_on_builder_inited_wraps_known_failures_as_extension_error(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    exc_factory: t.Callable[[], SphinxViteBuilderError],
+) -> None:
+    """Wrap a ``SphinxViteBuilderError`` as a modname-tagged ExtensionError.
+
+    Users see ``Extension error (sphinx_vite_builder)`` instead of
+    the internal module path.
+    """
+    web_dir = tmp_path / "web"
+    web_dir.mkdir()
+
+    original_exc = exc_factory()
+
+    def _raise(*, project_root: pathlib.Path) -> None:
+        raise original_exc
+
+    monkeypatch.setattr(hooks, "run_vite_build", _raise)
+
+    app = _FakeApp(
+        config=_FakeConfig(
+            sphinx_vite_builder_mode="auto",
+            sphinx_vite_builder_root=str(web_dir),
+        ),
+    )
     with pytest.raises(ExtensionError) as excinfo:
         hooks.on_builder_inited(app)  # type: ignore[arg-type]
 
     assert excinfo.value.modname == "sphinx_vite_builder"
-    assert isinstance(excinfo.value.orig_exc, PnpmMissingError)
-    assert isinstance(excinfo.value.__cause__, PnpmMissingError)
-    assert "pnpm is not on PATH" in str(excinfo.value)
+    assert excinfo.value.__cause__ is original_exc
 
 
-def test_dev_mode_spawn_failure_raises_extension_error_with_modname(
-    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+def test_on_build_finished_silent_on_success() -> None:
+    """No exception → handler completes without raising."""
+    app = _FakeApp()
+    hooks.on_build_finished(app, exception=None)  # type: ignore[arg-type]
+
+
+def test_on_build_finished_logs_exception_at_debug(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A typed diagnostic from DEV-mode bus.call_sync → ExtensionError.
+    """Exception → handler logs and does not raise.
 
-    The DEV-mode path doesn't go through run_vite_build; it spawns the
-    long-running watch via bus.call_sync(proc.start(...)) directly. Any
-    SphinxViteBuilderError surfacing through the bus should still get
-    the same ExtensionError(modname='sphinx_vite_builder') treatment.
+    Uses a direct logger.debug capture rather than caplog because the
+    Sphinx ``SphinxLoggerAdapter`` does not propagate to the root
+    logger that caplog hooks into.
     """
-
-    class _ExplodingProc:
-        async def start(self, command: tuple[str, ...], *, cwd: pathlib.Path) -> None:
-            del command, cwd
-            msg = "simulated vite spawn failure"
-            raise SphinxViteBuilderError(msg)
-
-    def _proc_factory(*, label: str = "", logger: object = None) -> _ExplodingProc:
-        del label, logger
-        return _ExplodingProc()
-
-    # Pre-create node_modules so _ensure_node_modules short-circuits.
-    (tmp_path / "node_modules").mkdir()
-    monkeypatch.setattr(hooks, "AsyncProcess", _proc_factory)
-
-    app = _FakeApp(
-        config=_FakeConfig(
-            sphinx_vite_builder_mode="dev",
-            sphinx_vite_builder_root=str(tmp_path),
-        ),
+    captured: list[tuple[str, tuple[t.Any, ...]]] = []
+    monkeypatch.setattr(
+        hooks.logger,
+        "debug",
+        lambda msg, *args: captured.append((msg, args)),
     )
 
-    try:
-        with pytest.raises(ExtensionError) as excinfo:
-            hooks.on_builder_inited(app)  # type: ignore[arg-type]
-    finally:
-        # The bus was started before the spawn raised — clean up so the
-        # daemon thread doesn't outlive the test.
-        bus = getattr(app, hooks._BUS_ATTR, None)
-        if bus is not None:
-            bus.stop(timeout=1.0)
-        setattr(app, hooks._BUS_ATTR, None)
+    app = _FakeApp()
+    exc = RuntimeError("boom")
+    hooks.on_build_finished(app, exception=exc)  # type: ignore[arg-type]
 
-    assert excinfo.value.modname == "sphinx_vite_builder"
-    assert isinstance(excinfo.value.orig_exc, SphinxViteBuilderError)
-    assert "simulated vite spawn failure" in str(excinfo.value)
-
-
-def test_dev_mode_oserror_from_missing_pnpm_raises_extension_error(
-    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """An ``OSError`` (typical: pnpm missing) → ExtensionError, not bare bubble.
-
-    ``asyncio.create_subprocess_exec`` raises ``FileNotFoundError`` (an
-    ``OSError`` subclass) when the executable isn't on PATH. Without
-    explicit handling, that bubbles to Sphinx's auto-wrap path with the
-    wrong modname; the catch in on_builder_inited surfaces it under
-    ``sphinx_vite_builder``.
-    """
-
-    class _OsErrorProc:
-        async def start(self, command: tuple[str, ...], *, cwd: pathlib.Path) -> None:
-            del command, cwd
-            raise FileNotFoundError(2, "No such file or directory: 'pnpm'")
-
-    def _proc_factory(*, label: str = "", logger: object = None) -> _OsErrorProc:
-        del label, logger
-        return _OsErrorProc()
-
-    (tmp_path / "node_modules").mkdir()
-    monkeypatch.setattr(hooks, "AsyncProcess", _proc_factory)
-
-    app = _FakeApp(
-        config=_FakeConfig(
-            sphinx_vite_builder_mode="dev",
-            sphinx_vite_builder_root=str(tmp_path),
-        ),
-    )
-
-    try:
-        with pytest.raises(ExtensionError) as excinfo:
-            hooks.on_builder_inited(app)  # type: ignore[arg-type]
-    finally:
-        bus = getattr(app, hooks._BUS_ATTR, None)
-        if bus is not None:
-            bus.stop(timeout=1.0)
-        setattr(app, hooks._BUS_ATTR, None)
-
-    assert excinfo.value.modname == "sphinx_vite_builder"
-    assert isinstance(excinfo.value.orig_exc, OSError)
+    assert len(captured) == 1
+    assert captured[0][1] == (exc,)


### PR DESCRIPTION
## Summary

- **Fix CSS/JS live-reload through `just start`** in `docs/`. Editing a `.css` or `.ts` file under `packages/*/web/src/` now propagates through vite, Sphinx's static-file copy, and the autobuild websocket reload in ~2 seconds end-to-end.
- **Diagnose the race**: `sphinx-autobuild` was watching only `docs/` (not `packages/`), and the DEV-mode hook spawned `pnpm exec vite build --watch` asynchronously — Sphinx's `copy_static_files` phase therefore finished *before* vite produced fresh assets, copying stale CSS/JS into `_build/_static/`. The atexit teardown then killed the watch on every sphinx-build subprocess exit, so it never persisted across rebuilds either.
- **Collapse the lifecycle to synchronous one-shot.** Both PROD and DEV now call `run_vite_build(...)`, which blocks on vite (~600ms). Removes the async-spawn / teardown / atexit machinery from the hook layer entirely.
- **Wire `sphinx-autobuild` to watch `../packages`** with five `--re-ignore` regex patterns guarding against rebuild loops: vite's output static dirs, `node_modules/`, `__pycache__/`, `.pytest_cache/`, `dist/`, and `_build/`.

## Changes by area

### `docs/justfile`

**`start` and `design` recipes**: pass `--watch ../packages` so workspace source edits trigger rebuilds. The five `--re-ignore` patterns scope the watch — `sphinx-autobuild`'s `IgnoreFilter` uses `fnmatch.fnmatch` which doesn't understand `**`, so rebuild-loop guards (especially the vite-output static dirs) use regex form.

### `packages/sphinx-vite-builder/src/sphinx_vite_builder/_internal/hooks.py`

**Synchronous one-shot in `on_builder_inited`.** Both modes funnel through `run_vite_build(project_root=…)`, which already handles the `SPHINX_VITE_BUILDER_SKIP` escape hatch, the `web/`-absent short-circuit, missing-`node_modules` auto-install, and typed fast-fail diagnostics (`PnpmMissingError`, `NodeModulesInstallError`, `ViteFailedError`).

**Remove async-spawn machinery**: `_ensure_node_modules` helper, `teardown()` / `_install_teardown_handlers()`, the three `_*_ATTR` constants stashed on the Sphinx app, the `_active_handles` weak registry, and eight unused imports. The `bus.py` and `process.py` modules stay — `run_vite_build` still uses them internally.

### `tests/test_sphinx_vite_builder_hooks.py`

**Rewrite around the simpler lifecycle.** Tests cover root-is-`None` no-op, `project_root` parent resolution, all-modes parametrisation (`auto` / `dev` / `prod`), `ExtensionError` wrapping for each `SphinxViteBuilderError` subclass, and `on_build_finished` pass-through. Uses `monkeypatch.setattr(hooks, "run_vite_build", ...)` to record calls without spawning subprocesses — materially faster than the prior fake-vite shell-script harness.

### `tests/test_sphinx_vite_builder_extension_integration.py`

**Integration test verifies `run_vite_build` fires through the full Sphinx entry-point chain.** The `conf.py`-level monkey-patch installs a recorder on `hooks.run_vite_build` and asserts the hook passes the right `project_root`.

## Design decisions

**Synchronous one-shot over async watch.** Alternative was making `vite build --watch` survive across `sphinx-autobuild`'s subprocess-per-build model via double-fork or an outer-process supervisor. Would have saved ~500ms per rebuild but required process supervision, IPC for the watch lifecycle, and a teardown path handling every sphinx-autobuild exit signal. The ~600ms synchronous round-trip is well inside the "feels instant" budget and removes the whole class of races.

**`--re-ignore` regex over `--ignore` glob.** `sphinx-autobuild`'s `IgnoreFilter` matches via `fnmatch.fnmatch`, which doesn't understand `**` as a multi-segment wildcard. The vite-output ignore pattern (`/packages/[^/]+/src/[^/]+/theme/[^/]+/static(/|$)`) needs to match the directory event itself plus descendants — `fnmatch` can't express that, regex can.

**Watch `../packages` (the whole workspace) over `../packages/*/web/src` (vite sources only).** Broader watch plus explicit ignore patterns lets Python source edits inside `packages/*/src/` also trigger rebuilds — useful when iterating extension code alongside its docs. The ignore set keeps the noise floor low.

**Aggressive over conservative dead-code removal.** The async-spawn machinery was private `_internal/` API never reachable to consumers. Keeping it as dormant scaffolding would have left ~600 lines of fake-vite test harness green but tied to a code path no production call hits. Tighter surface that exactly matches runtime behavior.

## Verification

The hook module no longer references the async-watch machinery:

```console
$ rg -n 'AsyncProcess|AsyncioBus|vite_watch_command|_install_teardown' packages/sphinx-vite-builder/src/sphinx_vite_builder/_internal/hooks.py
```

Expect zero matches.

The watch and ignore flags are wired into both recipes:

```console
$ grep -E "(--watch ../packages|re-ignore.*static)" docs/justfile
```

Expect matches in both `start` and `design`.

## Test plan

- [x] `uv run ruff check . --fix --show-fixes` — clean
- [x] `uv run ruff format .` — no diff
- [x] `uv run mypy` — passes across the workspace
- [x] `uv run pytest --reruns 0 -q` — full suite green, including the rewritten `test_sphinx_vite_builder_hooks.py` and `test_sphinx_vite_builder_extension_integration.py`
- [x] `rm -rf docs/_build && just build-docs` — build succeeded, no warnings or errors
- [x] **End-to-end live-reload**: edit `packages/gp-furo-theme/web/src/scripts/furo.ts`, `[sphinx-autobuild] Detected changes` fires in <1s, marker propagates through vite output → `docs/_build/_static/scripts/furo.js`, browser auto-refreshes via autobuild's websocket
- [x] `ps -ef | grep -E "vite|pnpm exec"` after a rebuild cycle — no orphan vite processes (confirms the async-spawn teardown problem is gone)