### PR TITLE
fix(theme[rocket-loader]) Opt remaining inline scripts out of Cloudflare Rocket Loader

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,24 +18,32 @@ $ uv add gp-sphinx --prerelease allow
 
 <!-- To maintainers and contributors: Please add notes for the forthcoming version below -->
 
+gp-sphinx 0.0.1a19 closes the gap on Cloudflare Rocket Loader
+compatibility by annotating every inline `<script>` block the bundled
+theme templates emit with `data-cfasync="false"`. The fix is
+invisible when Rocket Loader is off; with it on, the sidebar projects
+section stops blank-flashing on navigation, Furo's body theme
+bootstrap script runs synchronously as designed, and the Python
+module index stays collapsed on the first frame.
+
 ### Fixes
 
-#### `gp-furo-theme` + `sphinx-gp-theme`: Opt remaining inline scripts out of Cloudflare Rocket Loader
+#### Cloudflare Rocket Loader compatibility on bundled theme scripts
 
-Three inline `<script>` blocks in the bundled theme templates were not
-carrying `data-cfasync="false"` and would be deferred by Cloudflare
-Rocket Loader when enabled: the sidebar-projects active-link toggle
-(`sphinx-gp-theme`), Furo's body no-flicker theme bootstrap, and the
-Python `genindex` `COLLAPSE_INDEX` setter (`gp-furo-theme`). The same
-design constraint documented at `gp_sphinx/config.py:730-755`, which
-already motivates the opt-outs on the two FOWT-prevention scripts, now
-covers these as well. Behavior is unchanged when Rocket Loader is off;
-with Rocket Loader on, the sidebar projects section no longer
-blank-flashes, Furo's no-flicker script runs synchronously as designed,
-and the Python module index stays collapsed on first paint. The
-`requestAnimationFrame` + `DOMContentLoaded` backups in the
-FOWT-prevention script in `gp_sphinx/config.py` are kept as
-belt-and-suspenders.
+Three inline `<script>` blocks in the bundled theme templates lacked
+the `data-cfasync="false"` opt-out: the `sphinx-gp-theme`
+sidebar-projects active-link toggle, Furo's body no-flicker theme
+bootstrap (`gp-furo-theme`), and the Python `genindex`
+`COLLAPSE_INDEX` setter (`gp-furo-theme`). With Rocket Loader
+enabled by a consumer's CDN configuration, these scripts would run
+too late and produce visible artifacts — a brief blank flash in the
+sidebar projects section, a flash-of-wrong-theme during the body
+bootstrap window, and an expanded `genindex` on first paint. Each
+script now carries the same opt-out the two flash-of-wrong-theme
+prevention scripts in `gp_sphinx/config.py` already use. A local
+copy of the sidebar projects template in this repository's
+`docs/_templates/sidebar/projects.html` is synced so the workspace's
+own site renders the fix on every build. (#39)
 
 ## gp-sphinx 0.0.1a18 (2026-05-10)
 

--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,25 @@ $ uv add gp-sphinx --prerelease allow
 
 <!-- To maintainers and contributors: Please add notes for the forthcoming version below -->
 
+### Fixes
+
+#### `gp-furo-theme` + `sphinx-gp-theme`: Opt remaining inline scripts out of Cloudflare Rocket Loader
+
+Three inline `<script>` blocks in the bundled theme templates were not
+carrying `data-cfasync="false"` and would be deferred by Cloudflare
+Rocket Loader when enabled: the sidebar-projects active-link toggle
+(`sphinx-gp-theme`), Furo's body no-flicker theme bootstrap, and the
+Python `genindex` `COLLAPSE_INDEX` setter (`gp-furo-theme`). The same
+design constraint documented at `gp_sphinx/config.py:730-755`, which
+already motivates the opt-outs on the two FOWT-prevention scripts, now
+covers these as well. Behavior is unchanged when Rocket Loader is off;
+with Rocket Loader on, the sidebar projects section no longer
+blank-flashes, Furo's no-flicker script runs synchronously as designed,
+and the Python module index stays collapsed on first paint. The
+`requestAnimationFrame` + `DOMContentLoaded` backups in the
+FOWT-prevention script in `gp_sphinx/config.py` are kept as
+belt-and-suspenders.
+
 ## gp-sphinx 0.0.1a18 (2026-05-10)
 
 gp-sphinx 0.0.1a18 ships curated autodoc rendering across the docs

--- a/docs/_templates/sidebar/projects.html
+++ b/docs/_templates/sidebar/projects.html
@@ -59,7 +59,7 @@
     </span>
   </p>
 </div>
-<script type="text/javascript">
+<script data-cfasync="false">
 (() => {
   const sidebar = document.getElementById("sidebar-projects");
   const loc = window.location;

--- a/packages/gp-furo-theme/src/gp_furo_theme/theme/gp-furo/base.html
+++ b/packages/gp-furo-theme/src/gp_furo_theme/theme/gp-furo/base.html
@@ -92,7 +92,7 @@
   </head>
   <body>
     {% block body %}
-    <script>
+    <script data-cfasync="false">
       document.body.dataset.theme = localStorage.getItem("theme") || "auto";
     </script>
     {% endblock %}

--- a/packages/gp-furo-theme/src/gp_furo_theme/theme/gp-furo/domainindex.html
+++ b/packages/gp-furo-theme/src/gp_furo_theme/theme/gp-furo/domainindex.html
@@ -8,7 +8,7 @@
 {% block scripts -%}
   {{ super() }}
   {%- if not embedded and collapse_index %}
-    <script>DOCUMENTATION_OPTIONS.COLLAPSE_INDEX = true</script>
+    <script data-cfasync="false">DOCUMENTATION_OPTIONS.COLLAPSE_INDEX = true</script>
   {%- endif -%}
 {%- endblock scripts %}
 

--- a/packages/sphinx-gp-theme/src/sphinx_gp_theme/theme/sidebar/projects.html
+++ b/packages/sphinx-gp-theme/src/sphinx_gp_theme/theme/sidebar/projects.html
@@ -59,7 +59,7 @@
     </span>
   </p>
 </div>
-<script type="text/javascript">
+<script data-cfasync="false">
 (() => {
   const sidebar = document.getElementById("sidebar-projects");
   const loc = window.location;

--- a/tests/test_gp_furo_theme.py
+++ b/tests/test_gp_furo_theme.py
@@ -71,6 +71,23 @@ def test_theme_conf_declares_furo_options() -> None:
         assert option in conf, f"theme.conf is missing the {option!r} option"
 
 
+def test_base_html_no_flicker_script_opts_out_of_rocket_loader() -> None:
+    """Furo's body theme bootstrap carries ``data-cfasync="false"``.
+
+    Furo's inline ``<script>document.body.dataset.theme =
+    localStorage.getItem("theme") || "auto";</script>`` runs at the top
+    of ``<body>`` to pre-set the theme attribute before any styled
+    content paints. Under Cloudflare Rocket Loader the script is
+    rewritten and deferred, so first paint can land in the wrong theme.
+    The FOWT-prevention head script in
+    ``packages/gp-sphinx/src/gp_sphinx/config.py:789-808`` is opted out
+    for the same reason; this body script was missed. See
+    ``config.py:730-755`` for the design rationale.
+    """
+    base = (get_theme_path() / "base.html").read_text()
+    assert 'data-cfasync="false"' in base
+
+
 def test_setup_registers_theme() -> None:
     """setup() registers the theme + hooks + post-transform with Sphinx."""
 

--- a/tests/test_gp_furo_theme.py
+++ b/tests/test_gp_furo_theme.py
@@ -88,6 +88,21 @@ def test_base_html_no_flicker_script_opts_out_of_rocket_loader() -> None:
     assert 'data-cfasync="false"' in base
 
 
+def test_domainindex_collapse_index_script_opts_out_of_rocket_loader() -> None:
+    """``COLLAPSE_INDEX`` setter carries ``data-cfasync="false"``.
+
+    The Python ``genindex`` template injects
+    ``<script>DOCUMENTATION_OPTIONS.COLLAPSE_INDEX = true</script>``
+    when ``collapse_index`` is configured. Without an opt-out, Rocket
+    Loader defers the assignment past the point where ``doctools.js``
+    reads ``COLLAPSE_INDEX``, so the index renders expanded on first
+    paint and re-collapses later. Opting out keeps the assignment
+    synchronous in document order.
+    """
+    tpl = (get_theme_path() / "domainindex.html").read_text()
+    assert 'data-cfasync="false"' in tpl
+
+
 def test_setup_registers_theme() -> None:
     """setup() registers the theme + hooks + post-transform with Sphinx."""
 

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -43,6 +43,22 @@ def test_theme_sidebar_projects_exists() -> None:
     assert (get_theme_path() / "sidebar" / "projects.html").is_file()
 
 
+def test_theme_sidebar_projects_opts_out_of_rocket_loader() -> None:
+    """Inline script in sidebar projects template carries ``data-cfasync="false"``.
+
+    Pairs with ``custom.css``'s ``#sidebar-projects:not(.ready)
+    {visibility:hidden}`` FOUC-hide rule: if Cloudflare Rocket Loader
+    defers the inline script that adds ``.ready``, the projects section
+    stays hidden until the deferred script runs, which can be tens of
+    seconds on slow networks. The opt-out keeps the script synchronous
+    in document order as designed. See
+    ``packages/gp-sphinx/src/gp_sphinx/config.py:730-755`` for the
+    broader Rocket Loader rationale.
+    """
+    template = (get_theme_path() / "sidebar" / "projects.html").read_text()
+    assert 'data-cfasync="false"' in template
+
+
 def test_theme_static_custom_css_exists() -> None:
     """Custom CSS is bundled in theme static."""
     assert (get_theme_path() / "static" / "css" / "custom.css").is_file()


### PR DESCRIPTION
## Summary

Four inline `<script>` blocks across the bundled theme templates were missing `data-cfasync="false"` and would be deferred by Cloudflare Rocket Loader when consumers enable it. The existing extensive docstring at [`packages/gp-sphinx/src/gp_sphinx/config.py:730-755`](../blob/main/packages/gp-sphinx/src/gp_sphinx/config.py#L730-L755) already documents Rocket Loader as a deliberate design constraint — and the two inline scripts in `config.py` (copybutton selector + FOWT-prevention) already carry the opt-out. This PR closes the remaining gaps found in a monorepo audit.

The change is purely additive — no logic, no CSS — and is a no-op when Rocket Loader is off. The `requestAnimationFrame` + `DOMContentLoaded` backups in the FOWT-prevention script in `gp_sphinx/config.py` are deliberately kept as belt-and-suspenders.

## Scope — four inline `<script>` blocks across four commits

| Commit | File | Change |
|---|---|---|
| 1 | `packages/sphinx-gp-theme/src/sphinx_gp_theme/theme/sidebar/projects.html:62` | Add `data-cfasync="false"`. Drop `type="text/javascript"` (Cloudflare's docs warn it can suppress the opt-out; HTML5 already defaults to JavaScript). |
| 2 | `packages/gp-furo-theme/src/gp_furo_theme/theme/gp-furo/base.html:95` | Furo's body no-flicker script (`document.body.dataset.theme = …`) → add `data-cfasync="false"`. |
| 3 | `packages/gp-furo-theme/src/gp_furo_theme/theme/gp-furo/domainindex.html:11` | `DOCUMENTATION_OPTIONS.COLLAPSE_INDEX = true` setter → add `data-cfasync="false"`. Smallest blast radius (only the Python `genindex` page). |
| 4 | `docs/_templates/sidebar/projects.html:62` | Sync the gp-sphinx-local override of the sidebar template with the same opt-out so the gp-sphinx docs site itself benefits, not just downstream consumers. |

## How the bug shows up in the wild

This branch grew out of a Playwright `PerformanceObserver({type:'layout-shift'})` profile against `libtmux-mcp.git-pull.com` (deferred ready toggle → projects sidebar blank-flash) and `vcspull.git-pull.com` (clean baseline, projects sidebar `.ready` ran fast). With Rocket Loader on, the symptoms are:

- **`projects.html`**: `#sidebar-projects:not(.ready){visibility:hidden}` in [`custom.css:24`](../blob/main/packages/sphinx-gp-theme/src/sphinx_gp_theme/theme/static/css/custom.css#L24) hides the "team git-pull / Tony Narlock:" section until the inline script adds `.ready`. Deferred script → section stays hidden through Rocket Loader's queue.
- **`base.html`**: Furo's body theme bootstrap runs after first paint instead of before → flash of wrong theme on cold load.
- **`domainindex.html`**: `COLLAPSE_INDEX` lands after `doctools.js` has already initialised → module index renders expanded then re-collapses.

## Verification

Verified locally per [AGENTS.md:99-105](../blob/main/AGENTS.md) on every commit:

```
uv run ruff format .
uv run pytest                                     (1604 passed, 160 skipped)
uv run ruff check . --fix --show-fixes
uv run mypy src tests                             (125 files clean)
```

Plus `just build-docs` after the final commit and grep of the rendered HTML — `docs/_build/html/index.html` carries **4** `data-cfasync="false"` opt-outs (was 2 before this branch), and `docs/_build/html/py-modindex/index.html` carries the COLLAPSE_INDEX opt-out.

## Regression tests

- `tests/test_theme.py::test_theme_sidebar_projects_opts_out_of_rocket_loader` — asserts `data-cfasync="false"` survives in `sphinx_gp_theme/theme/sidebar/projects.html`.
- `tests/test_gp_furo_theme.py::test_base_html_no_flicker_script_opts_out_of_rocket_loader` — asserts the attribute in `gp-furo/base.html`.
- `tests/test_gp_furo_theme.py::test_domainindex_collapse_index_script_opts_out_of_rocket_loader` — asserts the attribute in `gp-furo/domainindex.html`.

## Test plan

- [x] `uv run ruff format .` clean
- [x] `uv run pytest` (1604 passed, 160 skipped)
- [x] `uv run ruff check .` clean
- [x] `uv run mypy src tests` clean
- [x] `just build-docs` succeeds
- [x] Rendered `index.html` has 4 `data-cfasync="false"` inline scripts (was 2)
- [x] Rendered `py-modindex/index.html` has the `COLLAPSE_INDEX` opt-out
- [ ] Downstream consumer (libtmux-mcp / vcspull) re-deploys against this version and re-profiles
- [ ] (Optional) Re-enable Cloudflare Rocket Loader on a test zone and confirm no FOUC on the projects sidebar / theme / module index

## CHANGES

Added `### Fixes` subsection under `## gp-sphinx 0.0.1a19 (unreleased)`.

## Out of scope

- Removing the `requestAnimationFrame` + `DOMContentLoaded` backups inside the FOWT-prevention script — those still protect against deferral from sources other than Rocket Loader.
- Changes to upstream Furo — `gp-furo-theme` already vendors its own copy of `base.html`, so the fix lands locally.