### PR TITLE
fix(theme[sidebar-logo]) Preload + fetchpriority=high for LCP element

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,39 @@ $ uv add gp-sphinx --prerelease allow
 
 <!-- To maintainers and contributors: Please add notes for the forthcoming version below -->
 
+gp-sphinx 0.0.1a20 closes a Largest-Contentful-Paint regression on
+the sidebar logo across every consumer docs site. Web-Vitals reports
+recorded LCP timings of 2.7 to 6.7 seconds because the bundled theme
+emitted a `<link rel="prefetch" as="image">` hint for the logo URLs
+instead of a `<link rel="preload" as="image" fetchpriority="high">`;
+the prefetch directive is reserved for future-navigation hints that
+browsers defer to idle. Switching the directive to `preload` plus
+`fetchpriority="high"` promotes the logo to the same critical-path
+priority the bundled fonts already use.
+
+### Fixes
+
+#### Sidebar logo loads as a critical-path resource
+
+Sidebar logos were the Largest Contentful Paint element on every
+consumer docs site with timings of 2.7 to 6.7 seconds. The
+`gp-furo-theme` template emitted `<link rel="prefetch">` hints for
+the logo URLs — a low-priority "future navigation" directive that
+browsers defer until idle — even though the logo sits above the
+fold on first paint. The fix switches the directive to
+`<link rel="preload" as="image" fetchpriority="high">`, mirroring
+the pattern already used for the bundled font preloads, and adds a
+matching `fetchpriority="high"` attribute to the `<img>` tag.
+
+Cumulative Layout Shift was already zero on these sites — the
+`<img>` carries `width="200" height="200"` so the browser reserves
+the 200×200 box before bytes arrive. As belt-and-suspenders for any
+consumer using `gp-furo-theme` standalone (without
+`sphinx-gp-theme`'s overlay), the `.sidebar-logo-container` CSS
+gains `aspect-ratio: 1 / 1` and `.sidebar-logo` gains
+`height: auto`, so the box reserves the same square regardless of
+whether the HTML attrs make it through theme customisations. (#40)
+
 ### Documentation
 
 #### Visual identity for the gp-sphinx docs site

--- a/docs/_templates/sidebar/brand.html
+++ b/docs/_templates/sidebar/brand.html
@@ -2,13 +2,13 @@
   {%- block brand_content %}
   {%- if logo_url %}
   <div class="sidebar-logo-container">
-    <img class="sidebar-logo" src="{{ logo_url }}" width="200" height="200" decoding="async" alt="Logo"/>
+    <img class="sidebar-logo" src="{{ logo_url }}" width="200" height="200" decoding="async" fetchpriority="high" alt="Logo"/>
   </div>
   {%- endif %}
   {%- if theme_light_logo and theme_dark_logo %}
   <div class="sidebar-logo-container">
-    <img class="sidebar-logo only-light" src="{{ pathto('_static/' + theme_light_logo, 1) }}" width="200" height="200" decoding="async" alt="Light Logo"/>
-    <img class="sidebar-logo only-dark" src="{{ pathto('_static/' + theme_dark_logo, 1) }}" width="200" height="200" decoding="async" alt="Dark Logo"/>
+    <img class="sidebar-logo only-light" src="{{ pathto('_static/' + theme_light_logo, 1) }}" width="200" height="200" decoding="async" fetchpriority="high" alt="Light Logo"/>
+    <img class="sidebar-logo only-dark" src="{{ pathto('_static/' + theme_dark_logo, 1) }}" width="200" height="200" decoding="async" fetchpriority="high" alt="Dark Logo"/>
   </div>
   {%- endif %}
   {% if not theme_sidebar_hide_name %}

--- a/packages/gp-furo-theme/src/gp_furo_theme/theme/gp-furo/base.html
+++ b/packages/gp-furo-theme/src/gp_furo_theme/theme/gp-furo/base.html
@@ -33,13 +33,18 @@
         <link rel="canonical" href="{{ pageurl|e }}">
         {%- endif %}
 
+        {#- The sidebar logo is the LCP element on most consumer docs sites.
+            `rel="preload"` (not `prefetch`) plus `fetchpriority="high"`
+            promotes it from idle-queue to critical-path, dropping LCP from
+            several seconds to sub-second. Block name is preserved for
+            backwards compatibility with downstream template overrides. -#}
         {%- block logo_prefetch_links %}
         {%- if logo_url %}
-        <link rel="prefetch" href="{{ logo_url }}" as="image">
+        <link rel="preload" href="{{ logo_url }}" as="image" fetchpriority="high">
         {%- endif %}
         {%- if theme_light_logo and theme_dark_logo %}
-        <link rel="prefetch" href="{{ pathto('_static/' + theme_light_logo, 1) }}" as="image">
-        <link rel="prefetch" href="{{ pathto('_static/' + theme_dark_logo, 1) }}" as="image">
+        <link rel="preload" href="{{ pathto('_static/' + theme_light_logo, 1) }}" as="image" fetchpriority="high">
+        <link rel="preload" href="{{ pathto('_static/' + theme_dark_logo, 1) }}" as="image" fetchpriority="high">
         {%- endif %}
         {%- endblock logo_prefetch_links %}
     {%- endblock linktags %}

--- a/packages/gp-furo-theme/src/gp_furo_theme/theme/gp-furo/sidebar/brand.html
+++ b/packages/gp-furo-theme/src/gp_furo_theme/theme/gp-furo/sidebar/brand.html
@@ -15,15 +15,19 @@ Hope your day's going well. :)
 <a class="sidebar-brand{% if logo %} centered{% endif %}" href="{{ pathto(master_doc) }}">
   {%- block brand_content %}
   {#- Remember to update the prefetch logic in `block logo_prefetch_links` in base.html #}
+  {#- width/height + decoding + fetchpriority let the browser reserve
+      the box before bytes arrive (CLS = 0) and treat the logo as a
+      critical-path resource (LCP wins). Mirrors sphinx-gp-theme's
+      sidebar/brand.html overlay. -#}
   {%- if logo_url %}
   <div class="sidebar-logo-container">
-    <img class="sidebar-logo" src="{{ logo_url }}" alt="Logo"/>
+    <img class="sidebar-logo" src="{{ logo_url }}" width="200" height="200" decoding="async" fetchpriority="high" alt="Logo"/>
   </div>
   {%- endif %}
   {%- if theme_light_logo and theme_dark_logo %}
   <div class="sidebar-logo-container">
-    <img class="sidebar-logo only-light" src="{{ pathto('_static/' + theme_light_logo, 1) }}" alt="Light Logo"/>
-    <img class="sidebar-logo only-dark" src="{{ pathto('_static/' + theme_dark_logo, 1) }}" alt="Dark Logo"/>
+    <img class="sidebar-logo only-light" src="{{ pathto('_static/' + theme_light_logo, 1) }}" width="200" height="200" decoding="async" fetchpriority="high" alt="Light Logo"/>
+    <img class="sidebar-logo only-dark" src="{{ pathto('_static/' + theme_dark_logo, 1) }}" width="200" height="200" decoding="async" fetchpriority="high" alt="Dark Logo"/>
   </div>
   {%- endif %}
   {% if not theme_sidebar_hide_name %}

--- a/packages/gp-furo-theme/web/src/styles/components/sidebar.css
+++ b/packages/gp-furo-theme/web/src/styles/components/sidebar.css
@@ -31,12 +31,20 @@
 
   .sidebar-logo-container {
     margin: var(--sidebar-item-spacing-vertical) 0;
+    /* Reserve a square box before the SVG bytes arrive. The img
+       carries width="200" height="200" attrs (CLS protection comes
+       from that primarily); this rule is belt-and-suspenders for
+       any consumer that loses the HTML attrs. Every shipped logo
+       (tmuxp.svg, libtmux.svg, libvcs.svg, cihai.svg) has a 1:1
+       viewBox. */
+    aspect-ratio: 1 / 1;
   }
 
   .sidebar-logo {
     margin: 0 auto;
     display: block;
     max-width: 100%;
+    height: auto;
   }
 
   /* Search input (sidebar-mounted) */

--- a/packages/sphinx-gp-theme/src/sphinx_gp_theme/theme/sidebar/brand.html
+++ b/packages/sphinx-gp-theme/src/sphinx_gp_theme/theme/sidebar/brand.html
@@ -2,13 +2,13 @@
   {%- block brand_content %}
   {%- if logo_url %}
   <div class="sidebar-logo-container">
-    <img class="sidebar-logo" src="{{ logo_url }}" width="200" height="200" decoding="async" alt="Logo"/>
+    <img class="sidebar-logo" src="{{ logo_url }}" width="200" height="200" decoding="async" fetchpriority="high" alt="Logo"/>
   </div>
   {%- endif %}
   {%- if theme_light_logo and theme_dark_logo %}
   <div class="sidebar-logo-container">
-    <img class="sidebar-logo only-light" src="{{ pathto('_static/' + theme_light_logo, 1) }}" width="200" height="200" decoding="async" alt="Light Logo"/>
-    <img class="sidebar-logo only-dark" src="{{ pathto('_static/' + theme_dark_logo, 1) }}" width="200" height="200" decoding="async" alt="Dark Logo"/>
+    <img class="sidebar-logo only-light" src="{{ pathto('_static/' + theme_light_logo, 1) }}" width="200" height="200" decoding="async" fetchpriority="high" alt="Light Logo"/>
+    <img class="sidebar-logo only-dark" src="{{ pathto('_static/' + theme_dark_logo, 1) }}" width="200" height="200" decoding="async" fetchpriority="high" alt="Dark Logo"/>
   </div>
   {%- endif %}
   {% if not theme_sidebar_hide_name %}


### PR DESCRIPTION
Production Web-Vitals reports recorded sidebar-logo LCP timings of 2.7 to 6.7 seconds on every git-pull docs site (libtmux, libvcs, vcspull, tmuxp, cihai, unihan-etl, ...). The bundled `gp-furo-theme/theme/gp-furo/base.html` template emitted a `<link rel="prefetch" as="image">` hint for the logo URLs — `prefetch` is a low-priority "future navigation" directive that browsers defer to idle, so the LCP element fetches alongside the spinner instead of alongside critical CSS/fonts. This PR upgrades the hint to `rel="preload"` plus `fetchpriority="high"`, mirroring the pattern already used for the bundled font preloads.

## Summary

- **Fix**: Switch logo `<link rel="prefetch">` to `<link rel="preload" as="image" fetchpriority="high">` in `gp-furo-theme/.../base.html`. The Jinja2 block name stays `logo_prefetch_links` for backwards compat with downstream template overrides.
- **Fix**: Add `fetchpriority="high"` to the `<img class="sidebar-logo">` tags in both `gp-furo-theme` and `sphinx-gp-theme` sidebar/brand templates. Bring gp-furo-theme's standalone template up to parity with sphinx-gp-theme by adding the `width="200" height="200" decoding="async"` attrs the overlay was already emitting.
- **Defense in depth**: `.sidebar-logo-container` gets `aspect-ratio: 1 / 1` CSS plus `.sidebar-logo` gets `height: auto`, so any consumer using gp-furo-theme without sphinx-gp-theme's overlay still reserves the square box without depending on the HTML `width`/`height` attrs surviving theme customisation.
- **CHANGES**: Lead paragraph + Fixes deliverable under `## gp-sphinx 0.0.1a20 (unreleased)`.

## Diagnosis

Live Playwright inspection of `https://libtmux.git-pull.com/` showed:

```
img.sidebar-logo: width="200" height="200" decoding="async"  ← CLS protection IS in place
link rel="prefetch" href=".../libtmux.svg" as="image"           ← LCP-critical resource on idle queue
link rel="preload" href=".../ibm-plex-sans-...woff2" as="font" ← fonts get the right hint
```

So Cumulative Layout Shift was already zero — the HTML `width`/`height` attrs reserve the box before bytes arrive. The remaining latency was purely the resource-hint mismatch.

## Authoring-surface impact

None. Consumer `conf.py` files set `html_theme_options.light_logo`/`dark_logo` exactly as before; the rendered HTML changes the `<link rel="...">` directive and adds `fetchpriority="high"` attributes. Downstream template overrides of the `logo_prefetch_links` block continue to work — only the contents of the block changed, not its name.

## Verification

After 0.0.1a20 ships and consumer docs redeploy, run a Playwright-based LCP/CLS sweep against every git-pull docs site using the snippet documented in the approved plan (`PerformanceObserver({ type: 'largest-contentful-paint' })` + `PerformanceObserver({ type: 'layout-shift' })`). Expected:

- `cls` < 0.1 (already true; this PR maintains it)
- `lcpMs` < 1000 (was 2700–6700 ms; expected dramatic improvement)
- `logoAttrs.fetchPriority === "high"`
- `imagePreloads >= 1` (logo is now preloaded)
- `imagePrefetches === 0` (no leftover prefetch hint)

## Test plan

- [x] `uv run ruff check . --fix --show-fixes` — clean
- [x] `uv run ruff format .` — clean
- [x] `uv run mypy` — clean
- [x] `uv run py.test --reruns 0 -vvv` — 1603 passed, 161 skipped, 0 failures
- [x] `just build-docs` — build succeeded, no template-rendering errors
- [ ] Post-merge: redeploy a consumer (e.g. libtmux-mcp) and confirm `<head>` carries `<link rel="preload" href=".../*.svg" as="image" fetchpriority="high">` and Web-Vitals LCP drops below 1s

Targeting gp-sphinx 0.0.1a20 (unreleased).
