### PR TITLE
Preload IBM Plex Mono 400 italic for code comments

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,16 @@ $ uv add gp-sphinx --prerelease allow
 
 <!-- To maintainers and contributors: Please add notes for the forthcoming version below -->
 
+### Fixes
+
+#### Code comments no longer trigger a font swap on first paint
+
+Furo renders code comments in italic, so any page with a commented
+code block lazy-loaded the IBM Plex Mono italic face and visibly
+re-rendered when it arrived. The face is now part of
+{py:data}`~gp_sphinx.defaults.DEFAULT_SPHINX_FONT_PRELOAD`, fetched
+alongside the other critical fonts. (#43)
+
 ## gp-sphinx 0.0.1a28 (2026-06-07)
 
 ### Development

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -130,7 +130,7 @@ These are injected even though they are not exposed as `DEFAULT_*` constants:
 | Constant | Value |
 | --- | --- |
 | `DEFAULT_SPHINX_FONTS` | IBM Plex Sans (400/500/600/700, normal+italic) and IBM Plex Mono (400, normal+italic) Fontsource definitions |
-| `DEFAULT_SPHINX_FONT_PRELOAD` | IBM Plex Sans 400 / 500 / 600 / 700 normal + 400 italic, IBM Plex Mono 400 / 700 normal |
+| `DEFAULT_SPHINX_FONT_PRELOAD` | IBM Plex Sans 400 / 500 / 600 / 700 normal + 400 italic, IBM Plex Mono 400 / 700 normal + 400 italic |
 | `DEFAULT_SPHINX_FONT_FALLBACKS` | Metric-adjusted Arial and Courier fallback declarations |
 | `DEFAULT_SPHINX_FONT_CSS_VARIABLES` | `--font-stack`, `--font-stack--monospace`, `--font-stack--headings` |
 

--- a/packages/gp-sphinx/src/gp_sphinx/defaults.py
+++ b/packages/gp-sphinx/src/gp_sphinx/defaults.py
@@ -239,6 +239,7 @@ DEFAULT_SPHINX_FONT_PRELOAD: list[tuple[str, int, str]] = [
     ("IBM Plex Sans", 400, "italic"),
     ("IBM Plex Mono", 400, "normal"),
     ("IBM Plex Mono", 700, "normal"),
+    ("IBM Plex Mono", 400, "italic"),
 ]
 """Font preload hints for critical rendering path.
 
@@ -252,13 +253,16 @@ The list covers every face Furo / ``furo-tw.css`` is observed to
 demand above the fold: body (Sans 400), headings + sidebar labels
 (Sans 500), epigraph blockquotes (Sans 600), strong / current
 sidebar (Sans 700), inline ``<em>`` and announcement-bar emphasis
-(Sans 400 italic), code blocks (Mono 400), and bold inline code
-``<strong><code>`` (Mono 700).
+(Sans 400 italic), code blocks (Mono 400), bold inline code
+``<strong><code>`` (Mono 700), and Pygments comment tokens
+(``.c`` / ``.c1`` / ``.cm``) which Furo's syntax style renders in
+italic (Mono 400 italic) -- a face triggered by every code block
+that carries a ``#`` comment.
 
 Examples
 --------
 >>> len(DEFAULT_SPHINX_FONT_PRELOAD)
-7
+8
 """
 
 DEFAULT_SPHINX_FONT_FALLBACKS: list[dict[str, str]] = [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -225,7 +225,7 @@ def test_merge_sphinx_config_default_fonts() -> None:
     )
     assert len(result["sphinx_fonts"]) == 2
     assert result["sphinx_fonts"][0]["family"] == "IBM Plex Sans"
-    assert len(result["sphinx_font_preload"]) == 7
+    assert len(result["sphinx_font_preload"]) == 8
     assert len(result["sphinx_font_fallbacks"]) == 2
     assert "--font-stack" in result["sphinx_font_css_variables"]
 


### PR DESCRIPTION
## Summary

- \`DEFAULT_SPHINX_FONT_PRELOAD\` now includes \`("IBM Plex Mono", 400, "italic")\`. Furo's Pygments style renders comment tokens (\`.c\`, \`.c1\`, \`.cm\`, \`.cs\`, \`.ch\`) in italic, so every code block with a \`#\` comment line was lazy-loading the mono-italic face on first encounter and producing a font swap.
- The face was already declared by \`DEFAULT_SPHINX_FONTS\` (Mono \`"styles": ["normal", "italic"]\`); this PR just promotes it from lazy to preload so the browser fetches it in parallel with the critical CSS.

## Test plan

- [x] \`uv run pytest tests/test_config.py\` (49 passed) — \`test_font_defaults\` bumped from \`== 7\` to \`== 8\`.
- [x] \`uv run pytest --doctest-modules packages/gp-sphinx/src/gp_sphinx/defaults.py\` (1 passed) — the embedded \`>>> len(DEFAULT_SPHINX_FONT_PRELOAD)\` doctest was bumped from 7 to 8 alongside the new tuple.
- [x] \`docs/configuration.md\` font-defaults table updated to reflect the new value.
- [x] Verified end-to-end in a downstream consumer (agentgrep): with the local-override version of this preload, the \`<link rel="preload" as="font" href="_static/fonts/ibm-plex-mono-latin-400-italic.woff2">\` tag appears in \`<head>\` and the browser no longer reports the italic mono face as a network resource on pages with code comments.

## Notes

Discovered while debugging a font-swap visible on every agentgrep docs page that has a Python code example with a \`# comment\` line. Filed the same fix project-level on agentgrep (\`docs/conf.py\` extends \`conf["sphinx_font_preload"]\`) — once this PR lands and gp-sphinx releases, that local override becomes redundant.