### PR TITLE
layout(fix[expandForHash]): listen for gp-sphinx:navigated on SPA navigation

### DIFF
--- a/packages/sphinx-ux-autodoc-layout/src/sphinx_ux_autodoc_layout/_static/js/layout.js
+++ b/packages/sphinx-ux-autodoc-layout/src/sphinx_ux_autodoc_layout/_static/js/layout.js
@@ -114,4 +114,5 @@
 
   document.addEventListener('DOMContentLoaded', expandForHash);
   window.addEventListener('hashchange', expandForHash);
+  document.addEventListener('gp-sphinx:navigated', expandForHash);
 })();


### PR DESCRIPTION
## Summary

- `layout.js` listens for `hashchange` to expand collapsed `<details>` ancestors and signature panels when navigating to a hash anchor
- `history.pushState()` (used by `spa-nav.js` for SPA navigation) does **not** fire `hashchange`, so `expandForHash()` never ran during SPA navigation
- Add `gp-sphinx:navigated` event listener alongside existing `DOMContentLoaded` and `hashchange` listeners — this custom event is already dispatched by `spa-nav.js` after every SPA DOM swap

## Test plan

- [ ] Navigate to a docs site with collapsed API signatures
- [ ] Click a cross-page link with a hash fragment (SPA navigation)
- [ ] Verify collapsed containers expand and page scrolls to the target
- [ ] Verify direct URL navigation (new tab) still works
- [ ] Verify browser back/forward still works