### PR TITLE
layout(fix[expandForHash]): scroll anchor target to top, not center

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,14 @@ $ uv add gp-sphinx --prerelease allow
 
 <!-- To maintainers and contributors: Please add notes for the forthcoming version below -->
 
+### Fixes
+
+#### `sphinx-ux-autodoc-layout`: Anchor targets scroll to viewport top, not center
+
+Hash navigation positioned the target element in the middle of the
+viewport instead of near the top, overriding the theme's
+`scroll-margin-top` rules. (#45)
+
 ## gp-sphinx 0.0.1a21 (2026-05-23)
 
 ### Fixes

--- a/packages/sphinx-ux-autodoc-layout/src/sphinx_ux_autodoc_layout/_static/js/layout.js
+++ b/packages/sphinx-ux-autodoc-layout/src/sphinx_ux_autodoc_layout/_static/js/layout.js
@@ -97,7 +97,8 @@
     expandSignatureForTarget(target);
 
     setTimeout(function () {
-      target.scrollIntoView({ block: 'center' });
+      // No block option: respect CSS scroll-margin-top from the theme.
+      target.scrollIntoView();
     }, 50);
   }
 

--- a/tests/ext/layout/test_js.py
+++ b/tests/ext/layout/test_js.py
@@ -1,0 +1,31 @@
+"""Regression tests for layout JS behavior contracts."""
+
+from __future__ import annotations
+
+import pathlib
+
+_LAYOUT_JS = pathlib.Path(
+    "packages/sphinx-ux-autodoc-layout"
+    "/src/sphinx_ux_autodoc_layout/_static/js/layout.js",
+)
+
+
+def test_scroll_into_view_does_not_center() -> None:
+    """expandForHash must not override scroll-margin-top with block center."""
+    js = _LAYOUT_JS.read_text(encoding="utf-8")
+
+    assert "block: 'center'" not in js, (
+        "layout.js must not use scrollIntoView({ block: 'center' }); "
+        "use scrollIntoView() to respect CSS scroll-margin-top"
+    )
+    assert 'block: "center"' not in js, (
+        'layout.js must not use scrollIntoView({ block: "center" }); '
+        "use scrollIntoView() to respect CSS scroll-margin-top"
+    )
+
+
+def test_expand_for_hash_calls_scroll_into_view() -> None:
+    """expandForHash must still call scrollIntoView to scroll to target."""
+    js = _LAYOUT_JS.read_text(encoding="utf-8")
+
+    assert "scrollIntoView()" in js


### PR DESCRIPTION
## Summary

- Fix `expandForHash()` positioning anchored elements in the middle of the viewport instead of at the top
- Remove `scrollIntoView({ block: 'center' })` in favor of `scrollIntoView()`, which defaults to `block: 'start'` and respects the theme's CSS `scroll-margin-top` rules (2.5rem desktop, calc with header-height on mobile)
- Add regression tests guarding against re-introducing `block: 'center'`

## Test plan

- [x] `uv run pytest --reruns 0 -vvv` — 1605 passed
- [x] `uv run mypy src tests` — no issues
- [x] `uv run ruff check .` — clean
- [x] `just build-docs` — build succeeded
- [ ] Visually verify: open a docs page with a hash anchor (e.g. `/api/#some.Class.method`) and confirm the target appears near the viewport top, not centered