### PR TITLE
Add source-file path and raw-source link to page footer

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,12 @@ $ uv add gp-sphinx --prerelease allow
 
 <!-- To maintainers and contributors: Please add notes for the forthcoming version below -->
 
+### What's new
+
+#### Source-file path in page footer
+
+Each page footer shows the source path and a raw-source link to GitHub. (#46)
+
 ## gp-sphinx 0.0.1a23 (2026-05-24)
 
 ## gp-sphinx 0.0.1a22 (2026-05-24)

--- a/packages/gp-furo-theme/src/gp_furo_theme/theme/gp-furo/page.html
+++ b/packages/gp-furo-theme/src/gp_furo_theme/theme/gp-furo/page.html
@@ -173,6 +173,23 @@
               {%- endtrans -%}
             </div>
             {%- endif %}
+            {%- if theme_source_repository and page_source_suffix -%}
+            {%- set _repo = theme_source_repository.rstrip("/") -%}
+            {%- set _subdir = theme_source_directory.rstrip("/") if theme_source_directory else "" -%}
+            {%- set _relpath = pagename + page_source_suffix -%}
+            {%- if _subdir -%}
+              {%- set _docpath = _subdir + "/" + _relpath -%}
+            {%- else -%}
+              {%- set _docpath = _relpath -%}
+            {%- endif -%}
+            <div class="page-source">
+              Source: <code>{{ _docpath }}</code>
+              {%- if theme_source_branch %}
+              &#183;
+              Machine-readable: <a class="muted-link" href="{{ _repo }}/raw/{{ theme_source_branch }}/{{ _docpath }}">Raw source</a>
+              {%- endif %}
+            </div>
+            {%- endif %}
           </div>
           <div class="right-details">
             {% if theme_footer_icons or READTHEDOCS -%}

--- a/packages/gp-furo-theme/web/src/styles/components/footer.css
+++ b/packages/gp-furo-theme/web/src/styles/components/footer.css
@@ -41,6 +41,19 @@
     font-size: var(--font-size--small);
   }
 
+  .bottom-of-page .page-source {
+    margin-top: 0.25rem;
+    font-size: var(--font-size--small);
+  }
+
+  .bottom-of-page .page-source code {
+    font-family: var(--font-stack--monospace);
+    font-size: 0.875em;
+    padding: 0.1em 0.25em;
+    background: var(--color-background-secondary);
+    border-radius: 0.2em;
+  }
+
   .bottom-of-page .right-details {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary

- **Add** a source-file provenance line to every documentation page footer, showing the repo-relative path (e.g. `docs/configuration.md`) and a "Raw source" link pointing to the raw file on GitHub
- **Guard** the new section on `theme_source_repository` and `page_source_suffix` so it only appears on content pages — generated pages like genindex and search are excluded automatically

## Design decisions

- **Reuse existing theme options**: The footer constructs its URL from `source_repository`, `source_branch`, and `source_directory` — all already declared in `theme.conf` and wired through `merge_sphinx_config()`. No new configuration surface needed.
- **`page_source_suffix` as the guard**: Sphinx leaves this variable falsy for generated pages, providing a natural exclusion mechanism without maintaining a hardcoded page-name list.
- **`/raw/` URL path**: GitHub's `/raw/{branch}/{path}` endpoint serves the unprocessed source file, matching the "machine-readable" intent. GitLab supports a similar endpoint at the same path segment.

## Verification

Verify the source line appears on content pages:

```console
$ grep -c "page-source" docs/_build/html/index.html
```

Verify the source line does not appear on generated pages:

```console
$ grep -c "page-source" docs/_build/html/genindex.html
```

## Test plan

- [x] `uv run pytest` — all existing tests pass
- [x] Built docs show `Source: docs/index.md · Machine-readable: Raw source` in footer on content pages
- [x] `genindex.html` and `search.html` have no source line
- [x] Raw source link resolves to correct GitHub URL (`/raw/main/docs/...`)