### PR TITLE
Pad standalone type chips, keep compound types flush

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,16 @@ $ uv add gp-sphinx --prerelease allow
 
 <!-- To maintainers and contributors: Please add notes for the forthcoming version below -->
 
+### Fixes
+
+#### Type chips in parameter lists regain their padding
+
+Standalone type annotations in autodoc parameter and return lists — a
+plain `str`, a `pathlib.Path`, the members of a union — rendered cramped
+against the edge of their chip background. They now get their horizontal
+breathing room back, while compound expressions such as `list[str]` and
+`dict[str, Any]` still render flush at their brackets. (#54)
+
 ## gp-sphinx 0.0.1a29 (2026-06-07)
 
 ### What's new

--- a/packages/sphinx-autodoc-typehints-gp/src/sphinx_autodoc_typehints_gp/_static/css/typehints_gp.css
+++ b/packages/sphinx-autodoc-typehints-gp/src/sphinx_autodoc_typehints_gp/_static/css/typehints_gp.css
@@ -47,15 +47,25 @@
    * blocks the compounding while still scaling with the root clamp
    * ramp on wide viewports.
    *
-   * `padding-inline: 0` cancels Furo's `padding: 0.1em 0.2em`
-   * horizontal component so the chip background sits flush against
-   * the bracket characters around it.  Without this, generic types
-   * read with visible whitespace inside the brackets — `list[ str ]`
-   * instead of `list[str]` — because the brackets and commas live
-   * outside the chip and have no padding of their own.  Vertical
-   * `0.1em` padding stays so the chip retains visible block height. */
+   * Keep Furo's `0.2em` horizontal padding so a standalone type chip
+   * (`str`, `pathlib.Path`) reads as a chip with breathing room rather
+   * than text crammed against its background edge.  The two overrides
+   * below cancel that padding only where a chip abuts `.p` punctuation
+   * (brackets, inner commas, pipes), so compound expressions still
+   * render flush — `list[str]`, not `list[ str ]` — because the
+   * brackets live outside the chip and have no padding of their own.
+   * Linked chips wrap the `<code>` in `<a>`, so the punctuation is the
+   * anchor's sibling; match both the bare and anchored forms. */
   .field-list code.literal {
     font-size: 0.8125rem;
-    padding-inline: 0;
+    padding-inline: 0.2em;
+  }
+  .field-list code.literal:has(+ .p),
+  .field-list a.reference:has(+ .p) > code.literal {
+    padding-inline-end: 0;
+  }
+  .field-list .p + code.literal,
+  .field-list .p + a.reference > code.literal {
+    padding-inline-start: 0;
   }
 }


### PR DESCRIPTION
## Summary

- **Fix** field-list type chips (`str`, `pathlib.Path`, union members) rendering with zero horizontal padding — each type sat crammed against the edge of its chip background.
- **Restore** Furo's `0.2em` inline padding on `.field-list code.literal`, which `sphinx-autodoc-typehints-gp` had zeroed globally.
- **Preserve** the tight compound rendering (`list[str]`, `dict[str, Any]`) by cancelling that padding only where a chip abuts `.p` punctuation.

## Background

`typehints_gp.css` zeroed `padding-inline` on every field-list code chip so compound annotations stayed flush — `list[str]`, not `list[ str ]`, since the brackets/commas live in separate `<span class="p">` elements outside the chip. The side effect: standalone types (a parameter that is just `str`, a return of `pathlib.Path`) lost their chip breathing room and read as text jammed against the background edge. The earlier api-facts padding fix only covered `.gp-sphinx-api-facts`, so plain autodoc parameter lists on consumer sites (libtmux, django-docutils, …) kept the cramped look.

## The fix

Restore the padding by default, then drop it adjacently to punctuation:

```css
.field-list code.literal { padding-inline: 0.2em; }
.field-list code.literal:has(+ .p),
.field-list a.reference:has(+ .p) > code.literal { padding-inline-end: 0; }
.field-list .p + code.literal,
.field-list .p + a.reference > code.literal { padding-inline-start: 0; }
```

Linked chips wrap the `<code>` in `<a>`, so the punctuation is the *anchor's* sibling — the rule matches both the bare and anchored forms. Browsers without `:has()` degrade gracefully to padded-everywhere.

## Before / After

| Chip | Context | Before | After |
|---|---|---|---|
| `str` | standalone | flush to edges | `0.2em` breathing room |
| `pathlib.Path` | standalone | flush to edges | `0.2em` breathing room |
| `Callable` | before `[` | flush | flush (unchanged) |
| `Server` | inside `[…]` | flush | flush (unchanged) |

Verified live: `dict[str, Any] | None` keeps `dict[str, Any]` tight while the `| None` members gain padding.

## Test plan

- [x] `uv run ruff check .` / `ruff format` / `uv run mypy .` clean
- [x] `uv run pytest --reruns 0` — full suite green
- [x] `just build-docs` succeeds; the rule is bundled into `_static/css/typehints_gp.css`
- [x] Prototyped live on a production consumer page; standalone chips padded, `list[str]`/`dict[str, Any]` stay flush